### PR TITLE
chore: add Dependabot updates for Gradle and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 15
+    labels:
+      - "type: dependencies"
+    groups:
+      gradle-patch-updates:
+        update-types:
+          - "patch"
+      gradle-minor-updates:
+        update-types:
+          - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    labels:
+      - "type: dependencies"
+    groups:
+      github-actions-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Add Dependabot configuration to automate weekly dependency updates.

Changes:
- Added `.github/dependabot.yml`
- Enabled weekly Gradle updates (`Asia/Seoul`, Monday)
- Enabled weekly GitHub Actions updates (`Asia/Seoul`, Monday)
- Applied `type: dependencies` label to Dependabot PRs
- Grouped updates to reduce PR noise:
  - `gradle-patch-updates`
  - `gradle-minor-updates`
  - `github-actions-updates`

## Related Issues

- Closes #7
- Related #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [x] Build/CI

## JSON-RPC Impact

Describe protocol-level impact, if any:

- [x] No protocol behavior change
- [ ] Request validation behavior changed
- [ ] Error mapping behavior changed
- [ ] Method registration/dispatch behavior changed

Details:
- Repository automation/configuration change only.

## Validation

- [ ] `./gradlew test`
- [ ] `./gradlew check`
- [ ] Added/updated tests for new behavior

## Documentation

- [ ] Updated README (if needed)
- [ ] Added migration notes for breaking changes (if any)
