### PR TITLE
feat(validation): align request/response validation and harden parsing/metrics behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,16 @@ Use `jsonrpc.validation.request.*` and `jsonrpc.validation.response.*` for fine-
 jsonrpc:
   validation:
     request:
+      require-id-member: false
+      allow-fractional-id: false
+      reject-response-fields: true
       params-type-violation-code-policy: INVALID_REQUEST
     response:
-      require-response-id-member: true
-      allow-fractional-response-id: false
-      allow-request-fields-in-response: false
+      require-id-member: true
+      allow-fractional-id: false
+      reject-request-fields: true
+      error-code:
+        policy: STANDARD_OR_SERVER_ERROR_RANGE
 ```
 
 For the full list of validation keys and defaults, see

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -211,14 +211,14 @@ The old keys below are migration references only.
 They are not bound by current auto-configuration and should not be used in new setups.
 Use the canonical symmetric keys in the right column.
 
-| Old key                                                           | New key                                              |
-|-------------------------------------------------------------------|------------------------------------------------------|
-| `jsonrpc.validation.response.require-response-id-member`          | `jsonrpc.validation.response.require-id-member`      |
-| `jsonrpc.validation.response.allow-null-response-id`              | `jsonrpc.validation.response.allow-null-id`          |
-| `jsonrpc.validation.response.allow-string-response-id`            | `jsonrpc.validation.response.allow-string-id`        |
-| `jsonrpc.validation.response.allow-numeric-response-id`           | `jsonrpc.validation.response.allow-numeric-id`       |
-| `jsonrpc.validation.response.allow-fractional-response-id`        | `jsonrpc.validation.response.allow-fractional-id`    |
-| `jsonrpc.validation.response.allow-request-fields-in-response`    | `jsonrpc.validation.response.reject-request-fields`  |
+| Old key                                                        | New key                                             |
+|----------------------------------------------------------------|-----------------------------------------------------|
+| `jsonrpc.validation.response.require-response-id-member`       | `jsonrpc.validation.response.require-id-member`     |
+| `jsonrpc.validation.response.allow-null-response-id`           | `jsonrpc.validation.response.allow-null-id`         |
+| `jsonrpc.validation.response.allow-string-response-id`         | `jsonrpc.validation.response.allow-string-id`       |
+| `jsonrpc.validation.response.allow-numeric-response-id`        | `jsonrpc.validation.response.allow-numeric-id`      |
+| `jsonrpc.validation.response.allow-fractional-response-id`     | `jsonrpc.validation.response.allow-fractional-id`   |
+| `jsonrpc.validation.response.allow-request-fields-in-response` | `jsonrpc.validation.response.reject-request-fields` |
 
 Inversion rule:
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -4,47 +4,47 @@ All properties are under `jsonrpc.*` and are bound to `JsonRpcProperties`.
 
 ## 1. Property Table
 
-| Key                                                             | Type                                  | Default                            | Description                                                          |
-|-----------------------------------------------------------------|---------------------------------------|------------------------------------|----------------------------------------------------------------------|
-| `jsonrpc.enabled`                                               | `boolean`                             | `true`                             | Enable/disable WebMVC endpoint auto-configuration                    |
-| `jsonrpc.path`                                                  | `String`                              | `/jsonrpc`                         | JSON-RPC HTTP endpoint path                                          |
-| `jsonrpc.max-batch-size`                                        | `int`                                 | `100`                              | Maximum number of entries allowed in one batch request               |
-| `jsonrpc.max-request-bytes`                                     | `int`                                 | `1048576`                          | Raw HTTP request payload size limit in bytes                         |
-| `jsonrpc.scan-annotated-methods`                                | `boolean`                             | `true`                             | Scan Spring beans for `@JsonRpcMethod`                               |
-| `jsonrpc.include-error-data`                                    | `boolean`                             | `false`                            | Include `JsonRpcException.data` in error responses                   |
-| `jsonrpc.validation.request.require-json-rpc-version-20`        | `boolean`                             | `true`                             | Require incoming request `jsonrpc` to equal `"2.0"`                 |
-| `jsonrpc.validation.request.require-id-member`                  | `boolean`                             | `false`                            | Require incoming requests to include an `id` member                  |
-| `jsonrpc.validation.request.allow-null-id`                      | `boolean`                             | `true`                             | Allow `id: null` in incoming requests                                |
-| `jsonrpc.validation.request.allow-string-id`                    | `boolean`                             | `true`                             | Allow string IDs in incoming requests                                |
-| `jsonrpc.validation.request.allow-numeric-id`                   | `boolean`                             | `true`                             | Allow numeric IDs in incoming requests                               |
-| `jsonrpc.validation.request.allow-fractional-id`                | `boolean`                             | `true`                             | Allow fractional numeric IDs in incoming requests                    |
-| `jsonrpc.validation.request.reject-response-fields`             | `boolean`                             | `false`                            | Reject request objects containing `result`/`error`                   |
-| `jsonrpc.validation.request.reject-duplicate-members`           | `boolean`                             | `false`                            | Reject duplicate members while parsing raw request JSON              |
-| `jsonrpc.validation.request.params-type-violation-code-policy`  | `INVALID_PARAMS` or `INVALID_REQUEST` | `INVALID_PARAMS`                   | Error code used when `params` exists but is neither object nor array |
-| `jsonrpc.validation.response.require-json-rpc-version-20`       | `boolean`                             | `true`                             | Require incoming response `jsonrpc` to equal `"2.0"`                 |
-| `jsonrpc.validation.response.require-id-member`                 | `boolean`                             | `true`                             | Require incoming responses to include an `id` member                 |
-| `jsonrpc.validation.response.allow-null-id`                     | `boolean`                             | `true`                             | Allow `id: null` in incoming responses                               |
-| `jsonrpc.validation.response.allow-string-id`                   | `boolean`                             | `true`                             | Allow string IDs in incoming responses                               |
-| `jsonrpc.validation.response.allow-numeric-id`                  | `boolean`                             | `true`                             | Allow numeric IDs in incoming responses                              |
-| `jsonrpc.validation.response.allow-fractional-id`               | `boolean`                             | `true`                             | Allow fractional numeric IDs in incoming responses                   |
-| `jsonrpc.validation.response.require-exclusive-result-or-error` | `boolean`                             | `true`                             | Require exactly one of `result` or `error`                           |
-| `jsonrpc.validation.response.require-error-object-when-present` | `boolean`                             | `true`                             | Require `error` to be an object when present                         |
-| `jsonrpc.validation.response.require-integer-error-code`        | `boolean`                             | `true`                             | Require `error.code` to be an integer                                |
-| `jsonrpc.validation.response.require-string-error-message`      | `boolean`                             | `true`                             | Require `error.message` to be a string                               |
-| `jsonrpc.validation.response.reject-request-fields`             | `boolean`                             | `false`                            | Reject response objects containing `method`/`params`                 |
-| `jsonrpc.validation.response.reject-duplicate-members`          | `boolean`                             | `false`                            | Reject duplicate members while parsing raw response JSON             |
-| `jsonrpc.validation.response.error-code.policy`                 | `JsonRpcResponseErrorCodePolicy`      | `ANY_INTEGER`                      | Accepted integer range policy for response `error.code`              |
-| `jsonrpc.validation.response.error-code.range.min`              | `Integer`                             | `null`                             | Inclusive minimum for `CUSTOM_RANGE`                                 |
-| `jsonrpc.validation.response.error-code.range.max`              | `Integer`                             | `null`                             | Inclusive maximum for `CUSTOM_RANGE`                                 |
-| `jsonrpc.method-registration-conflict-policy`                   | `REJECT` or `REPLACE`                 | `REJECT`                           | Duplicate method name registration policy                            |
-| `jsonrpc.method-allowlist`                                      | `List<String>`                        | `[]`                               | Allowlist for method access filtering                                |
-| `jsonrpc.method-denylist`                                       | `List<String>`                        | `[]`                               | Denylist for method access filtering (higher priority)               |
-| `jsonrpc.metrics-enabled`                                       | `boolean`                             | `true`                             | Enable Micrometer interceptor/observer when registry is present      |
-| `jsonrpc.metrics-latency-histogram-enabled`                     | `boolean`                             | `false`                            | Publish latency histogram buckets                                    |
-| `jsonrpc.metrics-latency-percentiles`                           | `List<Double>`                        | `[]`                               | Optional latency percentiles (`0.0 < p < 1.0`)                       |
-| `jsonrpc.metrics-max-method-tag-values`                         | `int`                                 | `100`                              | Max distinct method tag values before fallback to `other`            |
-| `jsonrpc.notification-executor-enabled`                         | `boolean`                             | `false`                            | Enable executor-backed notification dispatch                         |
-| `jsonrpc.notification-executor-bean-name`                       | `String`                              | `""`                               | Preferred executor bean name for notifications                       |
+| Key                                                             | Type                                  | Default          | Description                                                          |
+|-----------------------------------------------------------------|---------------------------------------|------------------|----------------------------------------------------------------------|
+| `jsonrpc.enabled`                                               | `boolean`                             | `true`           | Enable/disable WebMVC endpoint auto-configuration                    |
+| `jsonrpc.path`                                                  | `String`                              | `/jsonrpc`       | JSON-RPC HTTP endpoint path                                          |
+| `jsonrpc.max-batch-size`                                        | `int`                                 | `100`            | Maximum number of entries allowed in one batch request               |
+| `jsonrpc.max-request-bytes`                                     | `int`                                 | `1048576`        | Raw HTTP request payload size limit in bytes                         |
+| `jsonrpc.scan-annotated-methods`                                | `boolean`                             | `true`           | Scan Spring beans for `@JsonRpcMethod`                               |
+| `jsonrpc.include-error-data`                                    | `boolean`                             | `false`          | Include `JsonRpcException.data` in error responses                   |
+| `jsonrpc.validation.request.require-json-rpc-version-20`        | `boolean`                             | `true`           | Require incoming request `jsonrpc` to equal `"2.0"`                  |
+| `jsonrpc.validation.request.require-id-member`                  | `boolean`                             | `false`          | Require incoming requests to include an `id` member                  |
+| `jsonrpc.validation.request.allow-null-id`                      | `boolean`                             | `true`           | Allow `id: null` in incoming requests                                |
+| `jsonrpc.validation.request.allow-string-id`                    | `boolean`                             | `true`           | Allow string IDs in incoming requests                                |
+| `jsonrpc.validation.request.allow-numeric-id`                   | `boolean`                             | `true`           | Allow numeric IDs in incoming requests                               |
+| `jsonrpc.validation.request.allow-fractional-id`                | `boolean`                             | `true`           | Allow fractional numeric IDs in incoming requests                    |
+| `jsonrpc.validation.request.reject-response-fields`             | `boolean`                             | `false`          | Reject request objects containing `result`/`error`                   |
+| `jsonrpc.validation.request.reject-duplicate-members`           | `boolean`                             | `false`          | Reject duplicate members while parsing raw request JSON              |
+| `jsonrpc.validation.request.params-type-violation-code-policy`  | `INVALID_PARAMS` or `INVALID_REQUEST` | `INVALID_PARAMS` | Error code used when `params` exists but is neither object nor array |
+| `jsonrpc.validation.response.require-json-rpc-version-20`       | `boolean`                             | `true`           | Require incoming response `jsonrpc` to equal `"2.0"`                 |
+| `jsonrpc.validation.response.require-id-member`                 | `boolean`                             | `true`           | Require incoming responses to include an `id` member                 |
+| `jsonrpc.validation.response.allow-null-id`                     | `boolean`                             | `true`           | Allow `id: null` in incoming responses                               |
+| `jsonrpc.validation.response.allow-string-id`                   | `boolean`                             | `true`           | Allow string IDs in incoming responses                               |
+| `jsonrpc.validation.response.allow-numeric-id`                  | `boolean`                             | `true`           | Allow numeric IDs in incoming responses                              |
+| `jsonrpc.validation.response.allow-fractional-id`               | `boolean`                             | `true`           | Allow fractional numeric IDs in incoming responses                   |
+| `jsonrpc.validation.response.require-exclusive-result-or-error` | `boolean`                             | `true`           | Require exactly one of `result` or `error`                           |
+| `jsonrpc.validation.response.require-error-object-when-present` | `boolean`                             | `true`           | Require `error` to be an object when present                         |
+| `jsonrpc.validation.response.require-integer-error-code`        | `boolean`                             | `true`           | Require `error.code` to be an integer                                |
+| `jsonrpc.validation.response.require-string-error-message`      | `boolean`                             | `true`           | Require `error.message` to be a string                               |
+| `jsonrpc.validation.response.reject-request-fields`             | `boolean`                             | `false`          | Reject response objects containing `method`/`params`                 |
+| `jsonrpc.validation.response.reject-duplicate-members`          | `boolean`                             | `false`          | Reject duplicate members while parsing raw response JSON             |
+| `jsonrpc.validation.response.error-code.policy`                 | `JsonRpcResponseErrorCodePolicy`      | `ANY_INTEGER`    | Accepted integer range policy for response `error.code`              |
+| `jsonrpc.validation.response.error-code.range.min`              | `Integer`                             | `null`           | Inclusive minimum for `CUSTOM_RANGE`                                 |
+| `jsonrpc.validation.response.error-code.range.max`              | `Integer`                             | `null`           | Inclusive maximum for `CUSTOM_RANGE`                                 |
+| `jsonrpc.method-registration-conflict-policy`                   | `REJECT` or `REPLACE`                 | `REJECT`         | Duplicate method name registration policy                            |
+| `jsonrpc.method-allowlist`                                      | `List<String>`                        | `[]`             | Allowlist for method access filtering                                |
+| `jsonrpc.method-denylist`                                       | `List<String>`                        | `[]`             | Denylist for method access filtering (higher priority)               |
+| `jsonrpc.metrics-enabled`                                       | `boolean`                             | `true`           | Enable Micrometer interceptor/observer when registry is present      |
+| `jsonrpc.metrics-latency-histogram-enabled`                     | `boolean`                             | `false`          | Publish latency histogram buckets                                    |
+| `jsonrpc.metrics-latency-percentiles`                           | `List<Double>`                        | `[]`             | Optional latency percentiles (`0.0 < p < 1.0`)                       |
+| `jsonrpc.metrics-max-method-tag-values`                         | `int`                                 | `100`            | Max distinct method tag values before fallback to `other`            |
+| `jsonrpc.notification-executor-enabled`                         | `boolean`                             | `false`          | Enable executor-backed notification dispatch                         |
+| `jsonrpc.notification-executor-bean-name`                       | `String`                              | `""`             | Preferred executor bean name for notifications                       |
 
 `JsonRpcResponseErrorCodePolicy` values:
 - `ANY_INTEGER`
@@ -207,7 +207,9 @@ jsonrpc:
 
 ## 6. Migration Notes (Response Validation Key Rename)
 
-Old keys replaced by canonical symmetric keys:
+The old keys below are migration references only.
+They are not bound by current auto-configuration and should not be used in new setups.
+Use the canonical symmetric keys in the right column.
 
 | Old key                                                           | New key                                              |
 |-------------------------------------------------------------------|------------------------------------------------------|

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -4,35 +4,53 @@ All properties are under `jsonrpc.*` and are bound to `JsonRpcProperties`.
 
 ## 1. Property Table
 
-| Key                                                             | Type                                  | Default          | Description                                                          |
-|-----------------------------------------------------------------|---------------------------------------|------------------|----------------------------------------------------------------------|
-| `jsonrpc.enabled`                                               | `boolean`                             | `true`           | Enable/disable WebMVC endpoint auto-configuration                    |
-| `jsonrpc.path`                                                  | `String`                              | `/jsonrpc`       | JSON-RPC HTTP endpoint path                                          |
-| `jsonrpc.max-batch-size`                                        | `int`                                 | `100`            | Maximum number of entries allowed in one batch request               |
-| `jsonrpc.max-request-bytes`                                     | `int`                                 | `1048576`        | Raw HTTP request payload size limit in bytes                         |
-| `jsonrpc.scan-annotated-methods`                                | `boolean`                             | `true`           | Scan Spring beans for `@JsonRpcMethod`                               |
-| `jsonrpc.include-error-data`                                    | `boolean`                             | `false`          | Include `JsonRpcException.data` in error responses                   |
-| `jsonrpc.validation.request.params-type-violation-code-policy`  | `INVALID_PARAMS` or `INVALID_REQUEST` | `INVALID_PARAMS` | Error code used when `params` exists but is neither object nor array |
-| `jsonrpc.validation.response.require-json-rpc-version-20`       | `boolean`                             | `true`           | Require incoming response `jsonrpc` to equal `"2.0"`                 |
-| `jsonrpc.validation.response.require-response-id-member`        | `boolean`                             | `true`           | Require incoming responses to include an `id` member                 |
-| `jsonrpc.validation.response.allow-null-response-id`            | `boolean`                             | `true`           | Allow `id: null` in incoming responses                               |
-| `jsonrpc.validation.response.allow-string-response-id`          | `boolean`                             | `true`           | Allow string IDs in incoming responses                               |
-| `jsonrpc.validation.response.allow-numeric-response-id`         | `boolean`                             | `true`           | Allow numeric IDs in incoming responses                              |
-| `jsonrpc.validation.response.allow-fractional-response-id`      | `boolean`                             | `true`           | Allow fractional numeric IDs in incoming responses                   |
-| `jsonrpc.validation.response.require-exclusive-result-or-error` | `boolean`                             | `true`           | Require exactly one of `result` or `error`                           |
-| `jsonrpc.validation.response.require-error-object-when-present` | `boolean`                             | `true`           | Require `error` to be an object when present                         |
-| `jsonrpc.validation.response.require-integer-error-code`        | `boolean`                             | `true`           | Require `error.code` to be an integer                                |
-| `jsonrpc.validation.response.require-string-error-message`      | `boolean`                             | `true`           | Require `error.message` to be a string                               |
-| `jsonrpc.validation.response.allow-request-fields-in-response`  | `boolean`                             | `true`           | Allow request-only fields (`method`/`params`) on responses           |
-| `jsonrpc.method-registration-conflict-policy`                   | `REJECT` or `REPLACE`                 | `REJECT`         | Duplicate method name registration policy                            |
-| `jsonrpc.method-allowlist`                                      | `List<String>`                        | `[]`             | Allowlist for method access filtering                                |
-| `jsonrpc.method-denylist`                                       | `List<String>`                        | `[]`             | Denylist for method access filtering (higher priority)               |
-| `jsonrpc.metrics-enabled`                                       | `boolean`                             | `true`           | Enable Micrometer interceptor/observer when registry is present      |
-| `jsonrpc.metrics-latency-histogram-enabled`                     | `boolean`                             | `false`          | Publish latency histogram buckets                                    |
-| `jsonrpc.metrics-latency-percentiles`                           | `List<Double>`                        | `[]`             | Optional latency percentiles (`0.0 < p < 1.0`)                       |
-| `jsonrpc.metrics-max-method-tag-values`                         | `int`                                 | `100`            | Max distinct method tag values before fallback to `other`            |
-| `jsonrpc.notification-executor-enabled`                         | `boolean`                             | `false`          | Enable executor-backed notification dispatch                         |
-| `jsonrpc.notification-executor-bean-name`                       | `String`                              | `""`             | Preferred executor bean name for notifications                       |
+| Key                                                             | Type                                  | Default                            | Description                                                          |
+|-----------------------------------------------------------------|---------------------------------------|------------------------------------|----------------------------------------------------------------------|
+| `jsonrpc.enabled`                                               | `boolean`                             | `true`                             | Enable/disable WebMVC endpoint auto-configuration                    |
+| `jsonrpc.path`                                                  | `String`                              | `/jsonrpc`                         | JSON-RPC HTTP endpoint path                                          |
+| `jsonrpc.max-batch-size`                                        | `int`                                 | `100`                              | Maximum number of entries allowed in one batch request               |
+| `jsonrpc.max-request-bytes`                                     | `int`                                 | `1048576`                          | Raw HTTP request payload size limit in bytes                         |
+| `jsonrpc.scan-annotated-methods`                                | `boolean`                             | `true`                             | Scan Spring beans for `@JsonRpcMethod`                               |
+| `jsonrpc.include-error-data`                                    | `boolean`                             | `false`                            | Include `JsonRpcException.data` in error responses                   |
+| `jsonrpc.validation.request.require-json-rpc-version-20`        | `boolean`                             | `true`                             | Require incoming request `jsonrpc` to equal `"2.0"`                 |
+| `jsonrpc.validation.request.require-id-member`                  | `boolean`                             | `false`                            | Require incoming requests to include an `id` member                  |
+| `jsonrpc.validation.request.allow-null-id`                      | `boolean`                             | `true`                             | Allow `id: null` in incoming requests                                |
+| `jsonrpc.validation.request.allow-string-id`                    | `boolean`                             | `true`                             | Allow string IDs in incoming requests                                |
+| `jsonrpc.validation.request.allow-numeric-id`                   | `boolean`                             | `true`                             | Allow numeric IDs in incoming requests                               |
+| `jsonrpc.validation.request.allow-fractional-id`                | `boolean`                             | `true`                             | Allow fractional numeric IDs in incoming requests                    |
+| `jsonrpc.validation.request.reject-response-fields`             | `boolean`                             | `false`                            | Reject request objects containing `result`/`error`                   |
+| `jsonrpc.validation.request.reject-duplicate-members`           | `boolean`                             | `false`                            | Reject duplicate members while parsing raw request JSON              |
+| `jsonrpc.validation.request.params-type-violation-code-policy`  | `INVALID_PARAMS` or `INVALID_REQUEST` | `INVALID_PARAMS`                   | Error code used when `params` exists but is neither object nor array |
+| `jsonrpc.validation.response.require-json-rpc-version-20`       | `boolean`                             | `true`                             | Require incoming response `jsonrpc` to equal `"2.0"`                 |
+| `jsonrpc.validation.response.require-id-member`                 | `boolean`                             | `true`                             | Require incoming responses to include an `id` member                 |
+| `jsonrpc.validation.response.allow-null-id`                     | `boolean`                             | `true`                             | Allow `id: null` in incoming responses                               |
+| `jsonrpc.validation.response.allow-string-id`                   | `boolean`                             | `true`                             | Allow string IDs in incoming responses                               |
+| `jsonrpc.validation.response.allow-numeric-id`                  | `boolean`                             | `true`                             | Allow numeric IDs in incoming responses                              |
+| `jsonrpc.validation.response.allow-fractional-id`               | `boolean`                             | `true`                             | Allow fractional numeric IDs in incoming responses                   |
+| `jsonrpc.validation.response.require-exclusive-result-or-error` | `boolean`                             | `true`                             | Require exactly one of `result` or `error`                           |
+| `jsonrpc.validation.response.require-error-object-when-present` | `boolean`                             | `true`                             | Require `error` to be an object when present                         |
+| `jsonrpc.validation.response.require-integer-error-code`        | `boolean`                             | `true`                             | Require `error.code` to be an integer                                |
+| `jsonrpc.validation.response.require-string-error-message`      | `boolean`                             | `true`                             | Require `error.message` to be a string                               |
+| `jsonrpc.validation.response.reject-request-fields`             | `boolean`                             | `false`                            | Reject response objects containing `method`/`params`                 |
+| `jsonrpc.validation.response.reject-duplicate-members`          | `boolean`                             | `false`                            | Reject duplicate members while parsing raw response JSON             |
+| `jsonrpc.validation.response.error-code.policy`                 | `JsonRpcResponseErrorCodePolicy`      | `ANY_INTEGER`                      | Accepted integer range policy for response `error.code`              |
+| `jsonrpc.validation.response.error-code.range.min`              | `Integer`                             | `null`                             | Inclusive minimum for `CUSTOM_RANGE`                                 |
+| `jsonrpc.validation.response.error-code.range.max`              | `Integer`                             | `null`                             | Inclusive maximum for `CUSTOM_RANGE`                                 |
+| `jsonrpc.method-registration-conflict-policy`                   | `REJECT` or `REPLACE`                 | `REJECT`                           | Duplicate method name registration policy                            |
+| `jsonrpc.method-allowlist`                                      | `List<String>`                        | `[]`                               | Allowlist for method access filtering                                |
+| `jsonrpc.method-denylist`                                       | `List<String>`                        | `[]`                               | Denylist for method access filtering (higher priority)               |
+| `jsonrpc.metrics-enabled`                                       | `boolean`                             | `true`                             | Enable Micrometer interceptor/observer when registry is present      |
+| `jsonrpc.metrics-latency-histogram-enabled`                     | `boolean`                             | `false`                            | Publish latency histogram buckets                                    |
+| `jsonrpc.metrics-latency-percentiles`                           | `List<Double>`                        | `[]`                               | Optional latency percentiles (`0.0 < p < 1.0`)                       |
+| `jsonrpc.metrics-max-method-tag-values`                         | `int`                                 | `100`                              | Max distinct method tag values before fallback to `other`            |
+| `jsonrpc.notification-executor-enabled`                         | `boolean`                             | `false`                            | Enable executor-backed notification dispatch                         |
+| `jsonrpc.notification-executor-bean-name`                       | `String`                              | `""`                               | Preferred executor bean name for notifications                       |
+
+`JsonRpcResponseErrorCodePolicy` values:
+- `ANY_INTEGER`
+- `STANDARD_ONLY`
+- `STANDARD_OR_SERVER_ERROR_RANGE`
+- `CUSTOM_RANGE`
 
 ## 2. Validation Rules (Fail Fast)
 
@@ -52,12 +70,18 @@ Startup fails with `IllegalArgumentException` when any of these conditions occur
 - `jsonrpc.validation.request` is null
 - `jsonrpc.validation.request.params-type-violation-code-policy` is null
 - `jsonrpc.validation.response` is null
+- `jsonrpc.validation.response.error-code` is null
+- `jsonrpc.validation.response.error-code.policy` is null
+- `jsonrpc.validation.response.error-code.range` is null
+- `jsonrpc.validation.response.require-integer-error-code=false` with `jsonrpc.validation.response.error-code.policy != ANY_INTEGER`
+- `jsonrpc.validation.response.error-code.policy=CUSTOM_RANGE` and either range bound is missing
+- `jsonrpc.validation.response.error-code.policy=CUSTOM_RANGE` and `range.min > range.max`
 - allowlist/denylist list itself is null
 - allowlist/denylist contains null or blank values
 
 ## 3. Runtime Behavior Priority
 
-## 3.1 Method access filtering
+### 3.1 Method access filtering
 
 Priority:
 
@@ -71,7 +95,7 @@ Rules:
 - if allowlist is non-empty, methods not in allowlist are denied
 - `rpc.*` methods are blocked by registry independently of allow/deny lists
 
-## 3.2 Notification executor resolution
+### 3.2 Notification executor resolution
 
 When `jsonrpc.notification-executor-enabled=true`, resolution order is:
 
@@ -82,7 +106,7 @@ When `jsonrpc.notification-executor-enabled=true`, resolution order is:
 
 If a configured bean name is missing, startup fails.
 
-## 3.3 Method registration conflict handling
+### 3.3 Method registration conflict handling
 
 - `REJECT`: first duplicate fails registration.
 - `REPLACE`: later registration wins.
@@ -108,7 +132,7 @@ Example environment variable mapping:
 
 ## 5. Example Configurations
 
-## 5.1 Baseline production profile
+### 5.1 Baseline production profile
 
 ```yaml
 jsonrpc:
@@ -120,32 +144,49 @@ jsonrpc:
   include-error-data: false
   validation:
     request:
+      require-json-rpc-version-20: true
+      require-id-member: false
+      allow-null-id: true
+      allow-string-id: true
+      allow-numeric-id: true
+      allow-fractional-id: true
+      reject-response-fields: false
+      reject-duplicate-members: false
       params-type-violation-code-policy: INVALID_PARAMS
     response:
       require-json-rpc-version-20: true
-      require-response-id-member: true
-      allow-null-response-id: true
-      allow-string-response-id: true
-      allow-numeric-response-id: true
-      allow-fractional-response-id: true
+      require-id-member: true
+      allow-null-id: true
+      allow-string-id: true
+      allow-numeric-id: true
+      allow-fractional-id: true
       require-exclusive-result-or-error: true
       require-error-object-when-present: true
       require-integer-error-code: true
       require-string-error-message: true
-      allow-request-fields-in-response: true
+      reject-request-fields: false
+      reject-duplicate-members: false
+      error-code:
+        policy: ANY_INTEGER
+        range:
+          min: null
+          max: null
   method-allowlist: [ ]
   method-denylist: [ ]
 ```
 
-## 5.2 Strict access profile
+### 5.2 Strict response error-code profile
 
 ```yaml
 jsonrpc:
-  method-allowlist: [ user.find, user.update ]
-  method-denylist: [ user.delete ]
+  validation:
+    response:
+      reject-request-fields: true
+      error-code:
+        policy: STANDARD_OR_SERVER_ERROR_RANGE
 ```
 
-## 5.3 Async notification profile
+### 5.3 Async notification profile
 
 ```yaml
 jsonrpc:
@@ -153,7 +194,7 @@ jsonrpc:
   notification-executor-bean-name: applicationTaskExecutor
 ```
 
-## 5.4 Metrics-rich profile
+### 5.4 Metrics-rich profile
 
 ```yaml
 jsonrpc:
@@ -163,7 +204,24 @@ jsonrpc:
   metrics-max-method-tag-values: 200
 ```
 
-## 6. IDE Auto-completion and Metadata
+## 6. Migration Notes (Response Validation Key Rename)
+
+Old keys replaced by canonical symmetric keys:
+
+| Old key                                                           | New key                                              |
+|-------------------------------------------------------------------|------------------------------------------------------|
+| `jsonrpc.validation.response.require-response-id-member`          | `jsonrpc.validation.response.require-id-member`      |
+| `jsonrpc.validation.response.allow-null-response-id`              | `jsonrpc.validation.response.allow-null-id`          |
+| `jsonrpc.validation.response.allow-string-response-id`            | `jsonrpc.validation.response.allow-string-id`        |
+| `jsonrpc.validation.response.allow-numeric-response-id`           | `jsonrpc.validation.response.allow-numeric-id`       |
+| `jsonrpc.validation.response.allow-fractional-response-id`        | `jsonrpc.validation.response.allow-fractional-id`    |
+| `jsonrpc.validation.response.allow-request-fields-in-response`    | `jsonrpc.validation.response.reject-request-fields`  |
+
+Inversion rule:
+
+- `reject-request-fields = !allow-request-fields-in-response`
+
+## 7. IDE Auto-completion and Metadata
 
 The project ships Spring Boot configuration metadata via:
 
@@ -173,10 +231,10 @@ The project ships Spring Boot configuration metadata via:
 This enables:
 
 - property key completion
-- enum value suggestions (`REJECT`, `REPLACE`, `INVALID_PARAMS`, `INVALID_REQUEST`)
+- enum value suggestions (`REJECT`, `REPLACE`, `INVALID_PARAMS`, `INVALID_REQUEST`, error-code policy values)
 - metadata hints in IntelliJ and Spring-aware tooling
 
-## 7. Related References
+## 8. Related References
 
 - Spring setup details: [`spring-boot-guide.md`](spring-boot-guide.md)
 - Binding and registration details: [`registration-and-binding.md`](registration-and-binding.md)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -93,7 +93,8 @@ Rules:
 
 - denylist always overrides allowlist
 - if allowlist is non-empty, methods not in allowlist are denied
-- `rpc.*` methods are blocked by registry independently of allow/deny lists
+- `rpc.*` methods are blocked by request validation, and also by the default registry independently of allow/deny
+  lists
 
 ### 3.2 Notification executor resolution
 
@@ -232,7 +233,11 @@ This enables:
 
 - property key completion
 - enum value suggestions (`REJECT`, `REPLACE`, `INVALID_PARAMS`, `INVALID_REQUEST`, error-code policy values)
+- example numeric suggestions for `jsonrpc.validation.response.error-code.range.min/max`
 - metadata hints in IntelliJ and Spring-aware tooling
+
+Hints are suggestions for IDE completion only. They do not restrict allowed runtime values unless validation rules
+explicitly enforce constraints.
 
 ## 8. Related References
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,12 @@
 - Failure diagnosis and fixes: [`troubleshooting.md`](troubleshooting.md)
 - Release and publish flow: [`release-checklist.md`](release-checklist.md)
 
-## 5. Repository-Level Docs
+## 5. Samples
+
+- Spring Boot sample: [`../samples/spring-boot-demo/README.md`](../samples/spring-boot-demo/README.md)
+- Pure Java sample: [`../samples/pure-java-demo/README.md`](../samples/pure-java-demo/README.md)
+
+## 6. Repository-Level Docs
 
 - Project overview: [`../README.md`](../README.md)
 - Contribution workflow: [`../CONTRIBUTING.md`](../CONTRIBUTING.md)

--- a/docs/protocol-and-compliance.md
+++ b/docs/protocol-and-compliance.md
@@ -55,6 +55,9 @@ Implementation constants are in `JsonRpcErrorCode` and messages in `JsonRpcConst
 - `JsonRpcResponseValidator`
 - `JsonRpcResponseValidationOptions`
 
+`DefaultJsonRpcResponseParser` can parse from `JsonNode`, `String`, or `byte[]`, and can optionally reject duplicate
+members during raw JSON parsing.
+
 These APIs are transport-agnostic and useful for bidirectional channels (for example WebSocket) where
 request/response envelopes may arrive on the same connection.
 

--- a/docs/protocol-and-compliance.md
+++ b/docs/protocol-and-compliance.md
@@ -79,18 +79,21 @@ This library does not expose predefined strict/lenient modes; policy is controll
 `JsonRpcResponseValidationOptions` exposes per-rule switches:
 
 - `requireJsonRpcVersion20` (default: `true`)
-- `requireResponseIdMember` (default: `true`)
-- `allowNullResponseId` (default: `true`)
-- `allowStringResponseId` (default: `true`)
-- `allowNumericResponseId` (default: `true`)
-- `allowFractionalResponseId` (default: `true`)
+- `requireIdMember` (default: `true`)
+- `allowNullId` (default: `true`)
+- `allowStringId` (default: `true`)
+- `allowNumericId` (default: `true`)
+- `allowFractionalId` (default: `true`)
 - `requireExclusiveResultOrError` (default: `true`)
 - `requireErrorObjectWhenPresent` (default: `true`)
 - `requireIntegerErrorCode` (default: `true`)
 - `requireStringErrorMessage` (default: `true`)
-- `allowRequestFieldsInResponse` (default: `true`)
+- `rejectRequestFields` (default: `false`)
+- `rejectDuplicateMembers` (default: `false`)
+- `errorCodePolicy` (default: `ANY_INTEGER`)
+- `errorCodeRangeMin` / `errorCodeRangeMax` (default: `null`, used with `CUSTOM_RANGE`)
 
-`allowRequestFieldsInResponse=true` is a compatibility default and is not an RFC MUST rule.
+`rejectRequestFields=false` is a compatibility default and is not an RFC MUST rule.
 
 ## `id` Handling Details
 

--- a/docs/protocol-and-compliance.md
+++ b/docs/protocol-and-compliance.md
@@ -114,8 +114,9 @@ This library does not expose predefined strict/lenient modes; policy is controll
 
 ## Reserved Method Namespace
 
-Methods starting with `rpc.` are rejected at registration (`IllegalArgumentException`) to preserve reserved namespace
-semantics.
+Methods starting with `rpc.` are treated as invalid requests during request validation (`-32600`).
+Default in-memory registration also rejects `rpc.*` method names (`IllegalArgumentException`), so both registration and
+dispatch paths preserve reserved namespace semantics.
 
 ## HTTP Mapping Notes
 

--- a/docs/pure-java-guide.md
+++ b/docs/pure-java-guide.md
@@ -207,6 +207,7 @@ JsonRpcDispatcher dispatcher = new JsonRpcDispatcher(
 ```
 
 This keeps protocol behavior while letting you customize policy and implementation.
+`maxBatchSize` must be greater than `0` (fail-fast `IllegalArgumentException` otherwise).
 
 `JsonRpcParamsTypeViolationCodePolicy` controls which code is used when request `params` is present but not
 an object/array:

--- a/docs/spring-boot-guide.md
+++ b/docs/spring-boot-guide.md
@@ -330,7 +330,8 @@ Rules:
 1. Empty allowlist means all methods are allowed unless denied.
 2. Non-empty allowlist means only listed methods are allowed.
 3. Denylist always wins over allowlist.
-4. `rpc.*` methods are blocked by registry regardless of allow/deny lists.
+4. `rpc.*` methods are blocked by JSON-RPC request validation and by the default registry regardless of
+   allow/deny lists.
 
 ## 8. Notification Execution Strategy
 

--- a/docs/spring-boot-guide.md
+++ b/docs/spring-boot-guide.md
@@ -255,6 +255,9 @@ Use configuration to change this behavior:
 jsonrpc:
   validation:
     request:
+      require-id-member: false
+      allow-fractional-id: false
+      reject-response-fields: true
       params-type-violation-code-policy: INVALID_REQUEST
 ```
 
@@ -269,16 +272,21 @@ jsonrpc:
   validation:
     response:
       require-json-rpc-version-20: true
-      require-response-id-member: true
-      allow-null-response-id: true
-      allow-string-response-id: true
-      allow-numeric-response-id: true
-      allow-fractional-response-id: true
+      require-id-member: true
+      allow-null-id: true
+      allow-string-id: true
+      allow-numeric-id: true
+      allow-fractional-id: true
       require-exclusive-result-or-error: true
       require-error-object-when-present: true
       require-integer-error-code: true
       require-string-error-message: true
-      allow-request-fields-in-response: true
+      reject-request-fields: false
+      error-code:
+        policy: ANY_INTEGER
+        range:
+          min: null
+          max: null
 ```
 
 You can override only the options you need. Example:
@@ -287,8 +295,10 @@ You can override only the options you need. Example:
 jsonrpc:
   validation:
     response:
-      allow-fractional-response-id: false
-      allow-request-fields-in-response: false
+      allow-fractional-id: false
+      reject-request-fields: true
+      error-code:
+        policy: STANDARD_OR_SERVER_ERROR_RANGE
 ```
 
 Auto-configuration exposes both `JsonRpcResponseValidationOptions` and

--- a/docs/spring-boot-guide.md
+++ b/docs/spring-boot-guide.md
@@ -10,14 +10,15 @@ Replace `latest-version` with the release you want to use.
 Maven:
 
 ```xml
+
 <properties>
   <jsonrpc.version>latest-version</jsonrpc.version>
 </properties>
 
 <dependency>
-  <groupId>io.github.limehee</groupId>
-  <artifactId>jsonrpc-spring-boot-starter</artifactId>
-  <version>${jsonrpc.version}</version>
+<groupId>io.github.limehee</groupId>
+<artifactId>jsonrpc-spring-boot-starter</artifactId>
+<version>${jsonrpc.version}</version>
 </dependency>
 ```
 
@@ -133,14 +134,19 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 class TypedRpcConfig {
 
-    record UpperIn(String value) {}
-    record UpperOut(String value) {}
+    record UpperIn(String value) {
+
+    }
+
+    record UpperOut(String value) {
+
+    }
 
     @Bean
     JsonRpcMethodRegistration typedUpperRegistration(JsonRpcTypedMethodHandlerFactory factory) {
         return JsonRpcMethodRegistration.of(
-                "typed.upper",
-                factory.unary(UpperIn.class, in -> new UpperOut(in.value().toUpperCase()))
+            "typed.upper",
+            factory.unary(UpperIn.class, in -> new UpperOut(in.value().toUpperCase()))
         );
     }
 }
@@ -182,12 +188,15 @@ jsonrpc:
 `params` is mapped as a whole to the single declared parameter type.
 
 ```java
+
 @JsonRpcMethod("greet")
 public String greet(GreetParams params) {
     return "hello " + params.name();
 }
 
-record GreetParams(String name) {}
+record GreetParams(String name) {
+
+}
 ```
 
 ### 5.2 Multi parameter methods
@@ -205,6 +214,7 @@ Named binding name resolution order:
 Example:
 
 ```java
+
 @JsonRpcMethod("sum")
 public int sum(@JsonRpcParam("left") int left, @JsonRpcParam("right") int right) {
     return left + right;
@@ -214,12 +224,21 @@ public int sum(@JsonRpcParam("left") int left, @JsonRpcParam("right") int right)
 Request:
 
 ```json
-{"jsonrpc":"2.0","method":"sum","params":{"left":1,"right":2},"id":1}
+{
+  "jsonrpc": "2.0",
+  "method": "sum",
+  "params": {
+    "left": 1,
+    "right": 2
+  },
+  "id": 1
+}
 ```
 
 Positional example:
 
 ```java
+
 @JsonRpcMethod("sum")
 public int sum(int left, int right) {
     return left + right;
@@ -229,7 +248,15 @@ public int sum(int left, int right) {
 Request:
 
 ```json
-{"jsonrpc":"2.0","method":"sum","params":[1,2],"id":1}
+{
+  "jsonrpc": "2.0",
+  "method": "sum",
+  "params": [
+    1,
+    2
+  ],
+  "id": 1
+}
 ```
 
 ### 5.3 Return mapping
@@ -303,8 +330,8 @@ jsonrpc:
 
 Auto-configuration exposes both `JsonRpcResponseValidationOptions` and
 `JsonRpcResponseValidator` beans, and also a `JsonRpcResponseParser` bean configured with
-`jsonrpc.validation.response.reject-duplicate-members`. These components are intended for client/bidirectional integrations and are
-not part of the default HTTP request dispatch path.
+`jsonrpc.validation.response.reject-duplicate-members`. These components are intended for client/bidirectional
+integrations and are not part of the default HTTP request dispatch path.
 
 ## 6. Control Scanning Scope
 
@@ -321,8 +348,8 @@ Properties:
 
 ```yaml
 jsonrpc:
-  method-allowlist: [math.sum, ping]
-  method-denylist: [admin.reset]
+  method-allowlist: [ math.sum, ping ]
+  method-denylist: [ admin.reset ]
 ```
 
 Rules:
@@ -375,7 +402,7 @@ Configuration:
 jsonrpc:
   metrics-enabled: true
   metrics-latency-histogram-enabled: true
-  metrics-latency-percentiles: [0.9, 0.95, 0.99]
+  metrics-latency-percentiles: [ 0.9, 0.95, 0.99 ]
   metrics-max-method-tag-values: 100
 ```
 
@@ -421,11 +448,25 @@ class RpcHttpConfig {
     @Bean
     JsonRpcHttpStatusStrategy jsonRpcHttpStatusStrategy() {
         return new JsonRpcHttpStatusStrategy() {
-            public HttpStatus statusForSingle(JsonRpcResponse response) { return HttpStatus.OK; }
-            public HttpStatus statusForBatch(List<JsonRpcResponse> responses) { return HttpStatus.OK; }
-            public HttpStatus statusForNotificationOnly() { return HttpStatus.NO_CONTENT; }
-            public HttpStatus statusForParseError() { return HttpStatus.BAD_REQUEST; }
-            public HttpStatus statusForRequestTooLarge() { return HttpStatus.PAYLOAD_TOO_LARGE; }
+            public HttpStatus statusForSingle(JsonRpcResponse response) {
+                return HttpStatus.OK;
+            }
+
+            public HttpStatus statusForBatch(List<JsonRpcResponse> responses) {
+                return HttpStatus.OK;
+            }
+
+            public HttpStatus statusForNotificationOnly() {
+                return HttpStatus.NO_CONTENT;
+            }
+
+            public HttpStatus statusForParseError() {
+                return HttpStatus.BAD_REQUEST;
+            }
+
+            public HttpStatus statusForRequestTooLarge() {
+                return HttpStatus.PAYLOAD_TOO_LARGE;
+            }
         };
     }
 }

--- a/docs/spring-boot-guide.md
+++ b/docs/spring-boot-guide.md
@@ -302,7 +302,8 @@ jsonrpc:
 ```
 
 Auto-configuration exposes both `JsonRpcResponseValidationOptions` and
-`JsonRpcResponseValidator` beans. They are intended for client/bidirectional integrations and are
+`JsonRpcResponseValidator` beans, and also a `JsonRpcResponseParser` bean configured with
+`jsonrpc.validation.response.reject-duplicate-members`. These components are intended for client/bidirectional integrations and are
 not part of the default HTTP request dispatch path.
 
 ## 6. Control Scanning Scope

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestParser.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestParser.java
@@ -31,6 +31,6 @@ public class DefaultJsonRpcRequestParser implements JsonRpcRequestParser {
 
         JsonNode params = node.get("params");
 
-        return new JsonRpcRequest(jsonrpc, id, method, params, idPresent);
+        return new JsonRpcRequest(jsonrpc, id, method, params, idPresent, node);
     }
 }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidator.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidator.java
@@ -41,7 +41,7 @@ public class DefaultJsonRpcRequestValidator implements JsonRpcRequestValidator {
     }
 
     /**
-     * Validates protocol version, method presence, id shape, and params type.
+     * Validates protocol version, method presence, reserved method namespace, id shape, and params type.
      *
      * @param request parsed request model
      * @throws JsonRpcException when request violates JSON-RPC 2.0 constraints
@@ -57,6 +57,9 @@ public class DefaultJsonRpcRequestValidator implements JsonRpcRequestValidator {
         }
 
         if (request.method() == null || request.method().isBlank()) {
+            throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+        }
+        if (request.method().startsWith(JsonRpcConstants.RESERVED_METHOD_PREFIX)) {
             throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
         }
 

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidator.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidator.java
@@ -1,6 +1,7 @@
 package com.limehee.jsonrpc.core;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
 /**
@@ -8,14 +9,22 @@ import tools.jackson.databind.JsonNode;
  */
 public class DefaultJsonRpcRequestValidator implements JsonRpcRequestValidator {
 
-    private final JsonRpcParamsTypeViolationCodePolicy paramsTypeViolationCodePolicy;
+    private final JsonRpcRequestValidationOptions options;
 
     /**
-     * Creates a validator using {@link JsonRpcParamsTypeViolationCodePolicy#INVALID_PARAMS} for invalid {@code params}
-     * type violations.
+     * Creates a validator with default request-validation options.
      */
     public DefaultJsonRpcRequestValidator() {
-        this(JsonRpcParamsTypeViolationCodePolicy.INVALID_PARAMS);
+        this(JsonRpcRequestValidationOptions.defaults());
+    }
+
+    /**
+     * Creates a validator with explicit request-validation options.
+     *
+     * @param options request-validation options
+     */
+    public DefaultJsonRpcRequestValidator(JsonRpcRequestValidationOptions options) {
+        this.options = Objects.requireNonNull(options, "options");
     }
 
     /**
@@ -24,9 +33,10 @@ public class DefaultJsonRpcRequestValidator implements JsonRpcRequestValidator {
      * @param paramsTypeViolationCodePolicy policy selecting the error code for invalid {@code params} type violations
      */
     public DefaultJsonRpcRequestValidator(JsonRpcParamsTypeViolationCodePolicy paramsTypeViolationCodePolicy) {
-        this.paramsTypeViolationCodePolicy = Objects.requireNonNull(
-            paramsTypeViolationCodePolicy,
-            "paramsTypeViolationCodePolicy"
+        this(
+            JsonRpcRequestValidationOptions.builder()
+                .paramsTypeViolationCodePolicy(paramsTypeViolationCodePolicy)
+                .build()
         );
     }
 
@@ -41,24 +51,69 @@ public class DefaultJsonRpcRequestValidator implements JsonRpcRequestValidator {
         if (request == null) {
             throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
         }
-        if (!JsonRpcConstants.VERSION.equals(request.jsonrpc())) {
+
+        if (options.requireJsonRpcVersion20() && !JsonRpcConstants.VERSION.equals(request.jsonrpc())) {
             throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
         }
+
         if (request.method() == null || request.method().isBlank()) {
             throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
         }
 
-        JsonNode id = request.id();
-        if (request.idPresent() && id != null && !id.isNull() && !id.isString() && !id.isNumber()) {
+        if (options.requireIdMember() && !request.idPresent()) {
             throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+        }
+
+        if (request.idPresent()) {
+            validateId(request.id());
+        }
+
+        if (options.rejectResponseFields()) {
+            JsonNode source = request.source();
+            if (source != null && (source.has("result") || source.has("error"))) {
+                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            }
         }
 
         JsonNode params = request.params();
         if (params != null && !params.isArray() && !params.isObject()) {
-            if (paramsTypeViolationCodePolicy == JsonRpcParamsTypeViolationCodePolicy.INVALID_REQUEST) {
+            if (options.paramsTypeViolationCodePolicy() == JsonRpcParamsTypeViolationCodePolicy.INVALID_REQUEST) {
                 throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
             }
             throw new JsonRpcException(JsonRpcErrorCode.INVALID_PARAMS, JsonRpcConstants.MESSAGE_INVALID_PARAMS);
         }
+    }
+
+    /**
+     * Validates request {@code id} against configured ID rules.
+     *
+     * @param id request id node
+     */
+    private void validateId(@Nullable JsonNode id) {
+        if (id == null || id.isNull()) {
+            if (!options.allowNullId()) {
+                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            }
+            return;
+        }
+
+        if (id.isString()) {
+            if (!options.allowStringId()) {
+                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            }
+            return;
+        }
+
+        if (id.isNumber()) {
+            if (!options.allowNumericId()) {
+                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            }
+            if (!options.allowFractionalId() && id.isFloatingPointNumber()) {
+                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            }
+            return;
+        }
+
+        throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
     }
 }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidator.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidator.java
@@ -49,22 +49,22 @@ public class DefaultJsonRpcRequestValidator implements JsonRpcRequestValidator {
     @Override
     public void validate(JsonRpcRequest request) {
         if (request == null) {
-            throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            throw invalidRequest();
         }
 
         if (options.requireJsonRpcVersion20() && !JsonRpcConstants.VERSION.equals(request.jsonrpc())) {
-            throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            throw invalidRequest();
         }
 
         if (request.method() == null || request.method().isBlank()) {
-            throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            throw invalidRequest();
         }
         if (request.method().startsWith(JsonRpcConstants.RESERVED_METHOD_PREFIX)) {
-            throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            throw invalidRequest();
         }
 
         if (options.requireIdMember() && !request.idPresent()) {
-            throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+            throw invalidRequest();
         }
 
         if (request.idPresent()) {
@@ -74,16 +74,16 @@ public class DefaultJsonRpcRequestValidator implements JsonRpcRequestValidator {
         if (options.rejectResponseFields()) {
             JsonNode source = request.source();
             if (source != null && (source.has("result") || source.has("error"))) {
-                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+                throw invalidRequest();
             }
         }
 
         JsonNode params = request.params();
         if (params != null && !params.isArray() && !params.isObject()) {
             if (options.paramsTypeViolationCodePolicy() == JsonRpcParamsTypeViolationCodePolicy.INVALID_REQUEST) {
-                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+                throw invalidRequest();
             }
-            throw new JsonRpcException(JsonRpcErrorCode.INVALID_PARAMS, JsonRpcConstants.MESSAGE_INVALID_PARAMS);
+            throw invalidParams();
         }
     }
 
@@ -95,28 +95,46 @@ public class DefaultJsonRpcRequestValidator implements JsonRpcRequestValidator {
     private void validateId(@Nullable JsonNode id) {
         if (id == null || id.isNull()) {
             if (!options.allowNullId()) {
-                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+                throw invalidRequest();
             }
             return;
         }
 
         if (id.isString()) {
             if (!options.allowStringId()) {
-                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+                throw invalidRequest();
             }
             return;
         }
 
         if (id.isNumber()) {
             if (!options.allowNumericId()) {
-                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+                throw invalidRequest();
             }
             if (!options.allowFractionalId() && id.isFloatingPointNumber()) {
-                throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+                throw invalidRequest();
             }
             return;
         }
 
-        throw new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+        throw invalidRequest();
+    }
+
+    /**
+     * Creates a standardized invalid-request exception.
+     *
+     * @return invalid-request exception
+     */
+    private JsonRpcException invalidRequest() {
+        return new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
+    }
+
+    /**
+     * Creates a standardized invalid-params exception.
+     *
+     * @return invalid-params exception
+     */
+    private JsonRpcException invalidParams() {
+        return new JsonRpcException(JsonRpcErrorCode.INVALID_PARAMS, JsonRpcConstants.MESSAGE_INVALID_PARAMS);
     }
 }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParser.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParser.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JacksonException;
-import tools.jackson.core.StreamReadFeature;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
@@ -15,9 +14,7 @@ import tools.jackson.databind.json.JsonMapper;
  */
 public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
 
-    private final ObjectMapper objectMapper;
-    private final ObjectMapper strictObjectMapper;
-    private final boolean rejectDuplicateMembers;
+    private final JsonRpcPayloadReader payloadReader;
 
     /**
      * Creates a parser with a default ObjectMapper and duplicate-member rejection disabled.
@@ -42,11 +39,10 @@ public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
      * @param rejectDuplicateMembers  {@code true} to reject duplicate members while parsing raw JSON input
      */
     public DefaultJsonRpcResponseParser(ObjectMapper objectMapper, boolean rejectDuplicateMembers) {
-        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
-        this.strictObjectMapper = objectMapper.rebuild()
-            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
-            .build();
-        this.rejectDuplicateMembers = rejectDuplicateMembers;
+        this.payloadReader = new JsonRpcPayloadReader(
+            Objects.requireNonNull(objectMapper, "objectMapper"),
+            rejectDuplicateMembers
+        );
     }
 
     /**
@@ -61,7 +57,7 @@ public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
             throw invalidResponseEnvelope();
         }
         try {
-            JsonNode node = parserMapper().readTree(payload);
+            JsonNode node = payloadReader.readTree(payload);
             return parse(node);
         } catch (JacksonException ex) {
             throw invalidResponseEnvelope();
@@ -80,7 +76,7 @@ public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
             throw invalidResponseEnvelope();
         }
         try {
-            JsonNode node = parserMapper().readTree(payload);
+            JsonNode node = payloadReader.readTree(payload);
             return parse(node);
         } catch (JacksonException ex) {
             throw invalidResponseEnvelope();
@@ -153,12 +149,4 @@ public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
         return new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, "Invalid response envelope");
     }
 
-    /**
-     * Returns the mapper configured according to duplicate-member policy.
-     *
-     * @return mapper used for parsing raw payloads
-     */
-    private ObjectMapper parserMapper() {
-        return rejectDuplicateMembers ? strictObjectMapper : objectMapper;
-    }
 }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParser.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParser.java
@@ -52,7 +52,7 @@ public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
      * @return parsed incoming response envelope
      * @throws JsonRpcException when JSON parsing fails or payload shape is invalid
      */
-    public JsonRpcIncomingResponseEnvelope parse(@Nullable String payload) {
+    public JsonRpcIncomingResponseEnvelope parse(String payload) {
         if (payload == null) {
             throw invalidResponseEnvelope();
         }
@@ -71,7 +71,7 @@ public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
      * @return parsed incoming response envelope
      * @throws JsonRpcException when JSON parsing fails or payload shape is invalid
      */
-    public JsonRpcIncomingResponseEnvelope parse(@Nullable byte[] payload) {
+    public JsonRpcIncomingResponseEnvelope parse(byte[] payload) {
         if (payload == null) {
             throw invalidResponseEnvelope();
         }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParser.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParser.java
@@ -35,8 +35,8 @@ public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
     /**
      * Creates a parser with explicit mapper and duplicate-member policy.
      *
-     * @param objectMapper            mapper used to parse raw JSON input
-     * @param rejectDuplicateMembers  {@code true} to reject duplicate members while parsing raw JSON input
+     * @param objectMapper           mapper used to parse raw JSON input
+     * @param rejectDuplicateMembers {@code true} to reject duplicate members while parsing raw JSON input
      */
     public DefaultJsonRpcResponseParser(ObjectMapper objectMapper, boolean rejectDuplicateMembers) {
         this.payloadReader = new JsonRpcPayloadReader(

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParser.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParser.java
@@ -2,13 +2,90 @@ package com.limehee.jsonrpc.core;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadFeature;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Default parser for incoming JSON-RPC response payloads.
  */
 public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
+
+    private final ObjectMapper objectMapper;
+    private final ObjectMapper strictObjectMapper;
+    private final boolean rejectDuplicateMembers;
+
+    /**
+     * Creates a parser with a default ObjectMapper and duplicate-member rejection disabled.
+     */
+    public DefaultJsonRpcResponseParser() {
+        this(JsonMapper.builder().build(), false);
+    }
+
+    /**
+     * Creates a parser with a default ObjectMapper and explicit duplicate-member policy.
+     *
+     * @param rejectDuplicateMembers {@code true} to reject duplicate members while parsing raw JSON input
+     */
+    public DefaultJsonRpcResponseParser(boolean rejectDuplicateMembers) {
+        this(JsonMapper.builder().build(), rejectDuplicateMembers);
+    }
+
+    /**
+     * Creates a parser with explicit mapper and duplicate-member policy.
+     *
+     * @param objectMapper            mapper used to parse raw JSON input
+     * @param rejectDuplicateMembers  {@code true} to reject duplicate members while parsing raw JSON input
+     */
+    public DefaultJsonRpcResponseParser(ObjectMapper objectMapper, boolean rejectDuplicateMembers) {
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+        this.strictObjectMapper = objectMapper.rebuild()
+            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+            .build();
+        this.rejectDuplicateMembers = rejectDuplicateMembers;
+    }
+
+    /**
+     * Parses a raw JSON string response payload.
+     *
+     * @param payload raw JSON string
+     * @return parsed incoming response envelope
+     * @throws JsonRpcException when JSON parsing fails or payload shape is invalid
+     */
+    public JsonRpcIncomingResponseEnvelope parse(@Nullable String payload) {
+        if (payload == null) {
+            throw invalidResponseEnvelope();
+        }
+        try {
+            JsonNode node = parserMapper().readTree(payload);
+            return parse(node);
+        } catch (JacksonException ex) {
+            throw invalidResponseEnvelope();
+        }
+    }
+
+    /**
+     * Parses raw JSON bytes response payload.
+     *
+     * @param payload raw JSON bytes
+     * @return parsed incoming response envelope
+     * @throws JsonRpcException when JSON parsing fails or payload shape is invalid
+     */
+    public JsonRpcIncomingResponseEnvelope parse(@Nullable byte[] payload) {
+        if (payload == null) {
+            throw invalidResponseEnvelope();
+        }
+        try {
+            JsonNode node = parserMapper().readTree(payload);
+            return parse(node);
+        } catch (JacksonException ex) {
+            throw invalidResponseEnvelope();
+        }
+    }
 
     /**
      * {@inheritDoc}
@@ -74,5 +151,14 @@ public class DefaultJsonRpcResponseParser implements JsonRpcResponseParser {
      */
     private JsonRpcException invalidResponseEnvelope() {
         return new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, "Invalid response envelope");
+    }
+
+    /**
+     * Returns the mapper configured according to duplicate-member policy.
+     *
+     * @return mapper used for parsing raw payloads
+     */
+    private ObjectMapper parserMapper() {
+        return rejectDuplicateMembers ? strictObjectMapper : objectMapper;
     }
 }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidator.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidator.java
@@ -33,15 +33,15 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
     @Override
     public void validate(JsonRpcIncomingResponse response) {
         if (response == null) {
-            throw invalid("response must not be null");
+            throw invalidRequest();
         }
 
         if (options.requireJsonRpcVersion20() && !JsonRpcConstants.VERSION.equals(response.jsonrpc())) {
-            throw invalid("response jsonrpc must be \"2.0\"");
+            throw invalidRequest();
         }
 
         if (options.requireIdMember() && !response.idPresent()) {
-            throw invalid("response id must be present");
+            throw invalidRequest();
         }
 
         if (response.idPresent()) {
@@ -52,14 +52,14 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
             boolean hasResult = response.resultPresent();
             boolean hasError = response.errorPresent();
             if (hasResult == hasError) {
-                throw invalid("response must contain exactly one of result or error");
+                throw invalidRequest();
             }
         }
 
         if (options.rejectRequestFields()) {
             JsonNode source = response.source();
             if (source != null && (source.has("method") || source.has("params"))) {
-                throw invalid("response must not contain request fields method/params");
+                throw invalidRequest();
             }
         }
 
@@ -76,29 +76,29 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
     private void validateId(@Nullable JsonNode id) {
         if (id == null || id.isNull()) {
             if (!options.allowNullId()) {
-                throw invalid("response id must not be null");
+                throw invalidRequest();
             }
             return;
         }
 
         if (id.isString()) {
             if (!options.allowStringId()) {
-                throw invalid("response string id is not allowed");
+                throw invalidRequest();
             }
             return;
         }
 
         if (id.isNumber()) {
             if (!options.allowNumericId()) {
-                throw invalid("response numeric id is not allowed");
+                throw invalidRequest();
             }
             if (!options.allowFractionalId() && id.isFloatingPointNumber()) {
-                throw invalid("response fractional numeric id is not allowed");
+                throw invalidRequest();
             }
             return;
         }
 
-        throw invalid("response id must be string, number, or null");
+        throw invalidRequest();
     }
 
     /**
@@ -108,7 +108,7 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
      */
     private void validateError(@Nullable JsonNode error) {
         if (options.requireErrorObjectWhenPresent() && (error == null || !error.isObject())) {
-            throw invalid("response error must be an object");
+            throw invalidRequest();
         }
 
         if (error == null || !error.isObject()) {
@@ -118,7 +118,7 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
         JsonNode code = error.get("code");
         if (options.requireIntegerErrorCode()) {
             if (code == null || !code.isNumber() || code.isFloatingPointNumber()) {
-                throw invalid("response error.code must be an integer");
+                throw invalidRequest();
             }
         }
         if (code != null && code.isNumber() && !code.isFloatingPointNumber()) {
@@ -128,19 +128,18 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
         JsonNode message = error.get("message");
         if (options.requireStringErrorMessage()) {
             if (message == null || !message.isString()) {
-                throw invalid("response error.message must be a string");
+                throw invalidRequest();
             }
         }
     }
 
     /**
-     * Creates a standardized invalid-response exception.
+     * Creates a standardized invalid-request exception.
      *
-     * @param message detail message
      * @return invalid-request exception
      */
-    private JsonRpcException invalid(String message) {
-        return new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, message);
+    private JsonRpcException invalidRequest() {
+        return new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, JsonRpcConstants.MESSAGE_INVALID_REQUEST);
     }
 
     /**
@@ -155,13 +154,13 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
         }
         if (policy == JsonRpcResponseErrorCodePolicy.STANDARD_ONLY) {
             if (!isStandardErrorCode(code)) {
-                throw invalid("response error.code must be one of JSON-RPC standard codes");
+                throw invalidRequest();
             }
             return;
         }
         if (policy == JsonRpcResponseErrorCodePolicy.STANDARD_OR_SERVER_ERROR_RANGE) {
             if (!isStandardErrorCode(code) && !isServerErrorRangeCode(code)) {
-                throw invalid("response error.code must be standard or server-error range");
+                throw invalidRequest();
             }
             return;
         }
@@ -169,10 +168,10 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
             Integer min = options.errorCodeRangeMin();
             Integer max = options.errorCodeRangeMax();
             if (min == null || max == null) {
-                throw invalid("response error.code custom range is not configured");
+                throw invalidRequest();
             }
             if (code < min || code > max) {
-                throw invalid("response error.code is outside configured custom range");
+                throw invalidRequest();
             }
         }
     }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidator.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidator.java
@@ -58,7 +58,7 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
 
         if (options.rejectRequestFields()) {
             JsonNode source = response.source();
-            if (source == null || source.has("method") || source.has("params")) {
+            if (source != null && (source.has("method") || source.has("params"))) {
                 throw invalid("response must not contain request fields method/params");
             }
         }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidator.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidator.java
@@ -40,7 +40,7 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
             throw invalid("response jsonrpc must be \"2.0\"");
         }
 
-        if (options.requireResponseIdMember() && !response.idPresent()) {
+        if (options.requireIdMember() && !response.idPresent()) {
             throw invalid("response id must be present");
         }
 
@@ -56,7 +56,7 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
             }
         }
 
-        if (!options.allowRequestFieldsInResponse()) {
+        if (options.rejectRequestFields()) {
             JsonNode source = response.source();
             if (source == null || source.has("method") || source.has("params")) {
                 throw invalid("response must not contain request fields method/params");
@@ -75,24 +75,24 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
      */
     private void validateId(@Nullable JsonNode id) {
         if (id == null || id.isNull()) {
-            if (!options.allowNullResponseId()) {
+            if (!options.allowNullId()) {
                 throw invalid("response id must not be null");
             }
             return;
         }
 
         if (id.isString()) {
-            if (!options.allowStringResponseId()) {
+            if (!options.allowStringId()) {
                 throw invalid("response string id is not allowed");
             }
             return;
         }
 
         if (id.isNumber()) {
-            if (!options.allowNumericResponseId()) {
+            if (!options.allowNumericId()) {
                 throw invalid("response numeric id is not allowed");
             }
-            if (!options.allowFractionalResponseId() && id.isFloatingPointNumber()) {
+            if (!options.allowFractionalId() && id.isFloatingPointNumber()) {
                 throw invalid("response fractional numeric id is not allowed");
             }
             return;
@@ -121,6 +121,9 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
                 throw invalid("response error.code must be an integer");
             }
         }
+        if (code != null && code.isNumber() && !code.isFloatingPointNumber()) {
+            validateErrorCodePolicy(code.intValue());
+        }
 
         JsonNode message = error.get("message");
         if (options.requireStringErrorMessage()) {
@@ -138,5 +141,63 @@ public class DefaultJsonRpcResponseValidator implements JsonRpcResponseValidator
      */
     private JsonRpcException invalid(String message) {
         return new JsonRpcException(JsonRpcErrorCode.INVALID_REQUEST, message);
+    }
+
+    /**
+     * Validates integer {@code error.code} value against configured range policy.
+     *
+     * @param code integer error code
+     */
+    private void validateErrorCodePolicy(int code) {
+        JsonRpcResponseErrorCodePolicy policy = options.errorCodePolicy();
+        if (policy == JsonRpcResponseErrorCodePolicy.ANY_INTEGER) {
+            return;
+        }
+        if (policy == JsonRpcResponseErrorCodePolicy.STANDARD_ONLY) {
+            if (!isStandardErrorCode(code)) {
+                throw invalid("response error.code must be one of JSON-RPC standard codes");
+            }
+            return;
+        }
+        if (policy == JsonRpcResponseErrorCodePolicy.STANDARD_OR_SERVER_ERROR_RANGE) {
+            if (!isStandardErrorCode(code) && !isServerErrorRangeCode(code)) {
+                throw invalid("response error.code must be standard or server-error range");
+            }
+            return;
+        }
+        if (policy == JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE) {
+            Integer min = options.errorCodeRangeMin();
+            Integer max = options.errorCodeRangeMax();
+            if (min == null || max == null) {
+                throw invalid("response error.code custom range is not configured");
+            }
+            if (code < min || code > max) {
+                throw invalid("response error.code is outside configured custom range");
+            }
+        }
+    }
+
+    /**
+     * Checks whether a code is one of the JSON-RPC standard error codes.
+     *
+     * @param code integer error code
+     * @return {@code true} when code is standard
+     */
+    private boolean isStandardErrorCode(int code) {
+        return code == JsonRpcErrorCode.PARSE_ERROR
+            || code == JsonRpcErrorCode.INVALID_REQUEST
+            || code == JsonRpcErrorCode.METHOD_NOT_FOUND
+            || code == JsonRpcErrorCode.INVALID_PARAMS
+            || code == JsonRpcErrorCode.INTERNAL_ERROR;
+    }
+
+    /**
+     * Checks whether a code belongs to the JSON-RPC server-error reserved range.
+     *
+     * @param code integer error code
+     * @return {@code true} when code is within {@code -32099..-32000}
+     */
+    private boolean isServerErrorRangeCode(int code) {
+        return code >= -32099 && code <= -32000;
     }
 }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcDispatcher.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcDispatcher.java
@@ -65,6 +65,7 @@ public class JsonRpcDispatcher {
      * @param exceptionResolver exception resolver
      * @param responseComposer  response composer
      * @param maxBatchSize      maximum number of elements allowed in batch payloads
+     * @throws IllegalArgumentException if {@code maxBatchSize <= 0}
      */
     public JsonRpcDispatcher(
         JsonRpcMethodRegistry methodRegistry,
@@ -99,6 +100,7 @@ public class JsonRpcDispatcher {
      * @param responseComposer  response composer
      * @param maxBatchSize      maximum number of elements allowed in batch payloads
      * @param interceptors      interceptor chain executed around request handling
+     * @throws IllegalArgumentException if {@code maxBatchSize <= 0}
      */
     public JsonRpcDispatcher(
         JsonRpcMethodRegistry methodRegistry,
@@ -135,6 +137,7 @@ public class JsonRpcDispatcher {
      * @param maxBatchSize         maximum number of elements allowed in batch payloads
      * @param interceptors         interceptor chain executed around request handling
      * @param notificationExecutor executor used for notification invocations
+     * @throws IllegalArgumentException if {@code maxBatchSize <= 0}
      */
     public JsonRpcDispatcher(
         JsonRpcMethodRegistry methodRegistry,
@@ -153,6 +156,9 @@ public class JsonRpcDispatcher {
         this.methodInvoker = Objects.requireNonNull(methodInvoker, "methodInvoker");
         this.exceptionResolver = Objects.requireNonNull(exceptionResolver, "exceptionResolver");
         this.responseComposer = Objects.requireNonNull(responseComposer, "responseComposer");
+        if (maxBatchSize <= 0) {
+            throw new IllegalArgumentException("maxBatchSize must be greater than 0");
+        }
         this.maxBatchSize = maxBatchSize;
         this.interceptors = List.copyOf(Objects.requireNonNull(interceptors, "interceptors"));
         this.hasInterceptors = !this.interceptors.isEmpty();

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcIncomingResponse.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcIncomingResponse.java
@@ -29,13 +29,13 @@ public record JsonRpcIncomingResponse(
     /**
      * Creates a response model without the original source node.
      *
-     * @param jsonrpc protocol version field value when textual; otherwise {@code null}
-     * @param id id field value when present; may be {@code null}
-     * @param idPresent whether the response explicitly contained an {@code id} member
-     * @param result result field value when present; may be {@code null}
+     * @param jsonrpc       protocol version field value when textual; otherwise {@code null}
+     * @param id            id field value when present; may be {@code null}
+     * @param idPresent     whether the response explicitly contained an {@code id} member
+     * @param result        result field value when present; may be {@code null}
      * @param resultPresent whether the response explicitly contained a {@code result} member
-     * @param error error field value when present; may be {@code null}
-     * @param errorPresent whether the response explicitly contained an {@code error} member
+     * @param error         error field value when present; may be {@code null}
+     * @param errorPresent  whether the response explicitly contained an {@code error} member
      */
     public JsonRpcIncomingResponse(
         @Nullable String jsonrpc,

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcIncomingResponse.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcIncomingResponse.java
@@ -6,7 +6,7 @@ import tools.jackson.databind.JsonNode;
 /**
  * Parsed incoming JSON-RPC response model preserving field presence semantics.
  *
- * @param source        original response object node
+ * @param source        original response object node; may be {@code null}
  * @param jsonrpc       protocol version field value when textual; otherwise {@code null}
  * @param id            id field value when present; may be {@code null}
  * @param idPresent     whether the response explicitly contained an {@code id} member
@@ -16,7 +16,7 @@ import tools.jackson.databind.JsonNode;
  * @param errorPresent  whether the response explicitly contained an {@code error} member
  */
 public record JsonRpcIncomingResponse(
-    JsonNode source,
+    @Nullable JsonNode source,
     @Nullable String jsonrpc,
     @Nullable JsonNode id,
     boolean idPresent,
@@ -25,5 +25,28 @@ public record JsonRpcIncomingResponse(
     @Nullable JsonNode error,
     boolean errorPresent
 ) {
+
+    /**
+     * Creates a response model without the original source node.
+     *
+     * @param jsonrpc protocol version field value when textual; otherwise {@code null}
+     * @param id id field value when present; may be {@code null}
+     * @param idPresent whether the response explicitly contained an {@code id} member
+     * @param result result field value when present; may be {@code null}
+     * @param resultPresent whether the response explicitly contained a {@code result} member
+     * @param error error field value when present; may be {@code null}
+     * @param errorPresent whether the response explicitly contained an {@code error} member
+     */
+    public JsonRpcIncomingResponse(
+        @Nullable String jsonrpc,
+        @Nullable JsonNode id,
+        boolean idPresent,
+        @Nullable JsonNode result,
+        boolean resultPresent,
+        @Nullable JsonNode error,
+        boolean errorPresent
+    ) {
+        this(null, jsonrpc, id, idPresent, result, resultPresent, error, errorPresent);
+    }
 
 }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcPayloadReader.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcPayloadReader.java
@@ -1,0 +1,59 @@
+package com.limehee.jsonrpc.core;
+
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Reads raw JSON payloads with optional duplicate-member rejection.
+ */
+public final class JsonRpcPayloadReader {
+
+    private final ObjectMapper objectMapper;
+    private final ObjectMapper strictObjectMapper;
+    private final boolean rejectDuplicateMembers;
+
+    /**
+     * Creates a reader bound to a mapper and duplicate-member policy.
+     *
+     * @param objectMapper mapper used for JSON parsing
+     * @param rejectDuplicateMembers {@code true} to reject duplicate object members
+     */
+    public JsonRpcPayloadReader(ObjectMapper objectMapper, boolean rejectDuplicateMembers) {
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+        this.strictObjectMapper = objectMapper.rebuild()
+            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+            .build();
+        this.rejectDuplicateMembers = rejectDuplicateMembers;
+    }
+
+    /**
+     * Reads JSON from text.
+     *
+     * @param payload raw JSON text
+     * @return parsed JSON node
+     * @throws JacksonException when payload cannot be parsed as JSON
+     */
+    public JsonNode readTree(@Nullable String payload) throws JacksonException {
+        return parserMapper().readTree(payload);
+    }
+
+    /**
+     * Reads JSON from bytes.
+     *
+     * @param payload raw JSON bytes
+     * @return parsed JSON node
+     * @throws JacksonException when payload cannot be parsed as JSON
+     */
+    public JsonNode readTree(@Nullable byte[] payload) throws JacksonException {
+        return parserMapper().readTree(payload);
+    }
+
+    private ObjectMapper parserMapper() {
+        return rejectDuplicateMembers ? strictObjectMapper : objectMapper;
+    }
+}
+

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcPayloadReader.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcPayloadReader.java
@@ -1,7 +1,6 @@
 package com.limehee.jsonrpc.core;
 
 import java.util.Objects;
-import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.StreamReadFeature;
 import tools.jackson.databind.JsonNode;
@@ -37,7 +36,7 @@ public final class JsonRpcPayloadReader {
      * @return parsed JSON node
      * @throws JacksonException when payload cannot be parsed as JSON
      */
-    public JsonNode readTree(@Nullable String payload) throws JacksonException {
+    public JsonNode readTree(String payload) throws JacksonException {
         return parserMapper().readTree(payload);
     }
 
@@ -48,7 +47,7 @@ public final class JsonRpcPayloadReader {
      * @return parsed JSON node
      * @throws JacksonException when payload cannot be parsed as JSON
      */
-    public JsonNode readTree(@Nullable byte[] payload) throws JacksonException {
+    public JsonNode readTree(byte[] payload) throws JacksonException {
         return parserMapper().readTree(payload);
     }
 
@@ -56,4 +55,3 @@ public final class JsonRpcPayloadReader {
         return rejectDuplicateMembers ? strictObjectMapper : objectMapper;
     }
 }
-

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcPayloadReader.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcPayloadReader.java
@@ -18,7 +18,7 @@ public final class JsonRpcPayloadReader {
     /**
      * Creates a reader bound to a mapper and duplicate-member policy.
      *
-     * @param objectMapper mapper used for JSON parsing
+     * @param objectMapper           mapper used for JSON parsing
      * @param rejectDuplicateMembers {@code true} to reject duplicate object members
      */
     public JsonRpcPayloadReader(ObjectMapper objectMapper, boolean rejectDuplicateMembers) {

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequest.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequest.java
@@ -11,14 +11,35 @@ import tools.jackson.databind.JsonNode;
  * @param method    method name; may be {@code null}
  * @param params    raw params payload; may be {@code null}
  * @param idPresent whether the original payload explicitly contained an {@code id} field
+ * @param source    original request object node; may be {@code null}
  */
 public record JsonRpcRequest(
     @Nullable String jsonrpc,
     @Nullable JsonNode id,
     @Nullable String method,
     @Nullable JsonNode params,
-    boolean idPresent
+    boolean idPresent,
+    @Nullable JsonNode source
 ) {
+
+    /**
+     * Creates a request without storing the original source node.
+     *
+     * @param jsonrpc   protocol version string from payload; may be {@code null}
+     * @param id        request id value; may be {@code null}
+     * @param method    method name; may be {@code null}
+     * @param params    raw params payload; may be {@code null}
+     * @param idPresent whether the original payload explicitly contained an {@code id} field
+     */
+    public JsonRpcRequest(
+        @Nullable String jsonrpc,
+        @Nullable JsonNode id,
+        @Nullable String method,
+        @Nullable JsonNode params,
+        boolean idPresent
+    ) {
+        this(jsonrpc, id, method, params, idPresent, null);
+    }
 
     /**
      * Determines whether this request is a notification.

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestValidationOptions.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestValidationOptions.java
@@ -14,6 +14,7 @@ public final class JsonRpcRequestValidationOptions {
     private final boolean allowNumericId;
     private final boolean allowFractionalId;
     private final boolean rejectResponseFields;
+    private final boolean rejectDuplicateMembers;
     private final JsonRpcParamsTypeViolationCodePolicy paramsTypeViolationCodePolicy;
 
     private JsonRpcRequestValidationOptions(Builder builder) {
@@ -24,6 +25,7 @@ public final class JsonRpcRequestValidationOptions {
         this.allowNumericId = builder.allowNumericId;
         this.allowFractionalId = builder.allowFractionalId;
         this.rejectResponseFields = builder.rejectResponseFields;
+        this.rejectDuplicateMembers = builder.rejectDuplicateMembers;
         this.paramsTypeViolationCodePolicy = builder.paramsTypeViolationCodePolicy;
     }
 
@@ -95,6 +97,13 @@ public final class JsonRpcRequestValidationOptions {
     }
 
     /**
+     * @return whether duplicate members should be rejected during raw request payload parsing
+     */
+    public boolean rejectDuplicateMembers() {
+        return rejectDuplicateMembers;
+    }
+
+    /**
      * @return error-code policy used when {@code params} exists but is neither object nor array
      */
     public JsonRpcParamsTypeViolationCodePolicy paramsTypeViolationCodePolicy() {
@@ -113,6 +122,7 @@ public final class JsonRpcRequestValidationOptions {
         private boolean allowNumericId = true;
         private boolean allowFractionalId = true;
         private boolean rejectResponseFields = false;
+        private boolean rejectDuplicateMembers = false;
         private JsonRpcParamsTypeViolationCodePolicy paramsTypeViolationCodePolicy =
             JsonRpcParamsTypeViolationCodePolicy.INVALID_PARAMS;
 
@@ -193,6 +203,17 @@ public final class JsonRpcRequestValidationOptions {
          */
         public Builder rejectResponseFields(boolean enabled) {
             this.rejectResponseFields = enabled;
+            return this;
+        }
+
+        /**
+         * Enables or disables duplicate member rejection while parsing raw request payloads.
+         *
+         * @param enabled {@code true} to reject duplicate members
+         * @return this builder
+         */
+        public Builder rejectDuplicateMembers(boolean enabled) {
+            this.rejectDuplicateMembers = enabled;
             return this;
         }
 

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestValidationOptions.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestValidationOptions.java
@@ -1,0 +1,219 @@
+package com.limehee.jsonrpc.core;
+
+import java.util.Objects;
+
+/**
+ * Fine-grained validation switches for incoming JSON-RPC request validation.
+ */
+public final class JsonRpcRequestValidationOptions {
+
+    private final boolean requireJsonRpcVersion20;
+    private final boolean requireIdMember;
+    private final boolean allowNullId;
+    private final boolean allowStringId;
+    private final boolean allowNumericId;
+    private final boolean allowFractionalId;
+    private final boolean rejectResponseFields;
+    private final JsonRpcParamsTypeViolationCodePolicy paramsTypeViolationCodePolicy;
+
+    private JsonRpcRequestValidationOptions(Builder builder) {
+        this.requireJsonRpcVersion20 = builder.requireJsonRpcVersion20;
+        this.requireIdMember = builder.requireIdMember;
+        this.allowNullId = builder.allowNullId;
+        this.allowStringId = builder.allowStringId;
+        this.allowNumericId = builder.allowNumericId;
+        this.allowFractionalId = builder.allowFractionalId;
+        this.rejectResponseFields = builder.rejectResponseFields;
+        this.paramsTypeViolationCodePolicy = builder.paramsTypeViolationCodePolicy;
+    }
+
+    /**
+     * Returns default validation options aligned with JSON-RPC 2.0 request semantics.
+     *
+     * @return default request-validation options
+     */
+    public static JsonRpcRequestValidationOptions defaults() {
+        return builder().build();
+    }
+
+    /**
+     * Creates a mutable builder initialized with default values.
+     *
+     * @return options builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * @return whether {@code jsonrpc=="2.0"} is required
+     */
+    public boolean requireJsonRpcVersion20() {
+        return requireJsonRpcVersion20;
+    }
+
+    /**
+     * @return whether the {@code id} member must exist on requests
+     */
+    public boolean requireIdMember() {
+        return requireIdMember;
+    }
+
+    /**
+     * @return whether {@code id:null} is allowed
+     */
+    public boolean allowNullId() {
+        return allowNullId;
+    }
+
+    /**
+     * @return whether string IDs are allowed
+     */
+    public boolean allowStringId() {
+        return allowStringId;
+    }
+
+    /**
+     * @return whether numeric IDs are allowed
+     */
+    public boolean allowNumericId() {
+        return allowNumericId;
+    }
+
+    /**
+     * @return whether fractional numeric IDs are allowed
+     */
+    public boolean allowFractionalId() {
+        return allowFractionalId;
+    }
+
+    /**
+     * @return whether requests containing response-only fields ({@code result}/{@code error}) are rejected
+     */
+    public boolean rejectResponseFields() {
+        return rejectResponseFields;
+    }
+
+    /**
+     * @return error-code policy used when {@code params} exists but is neither object nor array
+     */
+    public JsonRpcParamsTypeViolationCodePolicy paramsTypeViolationCodePolicy() {
+        return paramsTypeViolationCodePolicy;
+    }
+
+    /**
+     * Builder for request validation options.
+     */
+    public static final class Builder {
+
+        private boolean requireJsonRpcVersion20 = true;
+        private boolean requireIdMember = false;
+        private boolean allowNullId = true;
+        private boolean allowStringId = true;
+        private boolean allowNumericId = true;
+        private boolean allowFractionalId = true;
+        private boolean rejectResponseFields = false;
+        private JsonRpcParamsTypeViolationCodePolicy paramsTypeViolationCodePolicy =
+            JsonRpcParamsTypeViolationCodePolicy.INVALID_PARAMS;
+
+        private Builder() {
+        }
+
+        /**
+         * Enables or disables strict validation of the {@code jsonrpc} version field.
+         *
+         * @param enabled {@code true} to require {@code "2.0"}
+         * @return this builder
+         */
+        public Builder requireJsonRpcVersion20(boolean enabled) {
+            this.requireJsonRpcVersion20 = enabled;
+            return this;
+        }
+
+        /**
+         * Enables or disables required presence of the {@code id} member.
+         *
+         * @param enabled {@code true} to require an {@code id} member
+         * @return this builder
+         */
+        public Builder requireIdMember(boolean enabled) {
+            this.requireIdMember = enabled;
+            return this;
+        }
+
+        /**
+         * Enables or disables support for explicit {@code id:null}.
+         *
+         * @param enabled {@code true} to accept null IDs
+         * @return this builder
+         */
+        public Builder allowNullId(boolean enabled) {
+            this.allowNullId = enabled;
+            return this;
+        }
+
+        /**
+         * Enables or disables support for textual IDs.
+         *
+         * @param enabled {@code true} to accept string IDs
+         * @return this builder
+         */
+        public Builder allowStringId(boolean enabled) {
+            this.allowStringId = enabled;
+            return this;
+        }
+
+        /**
+         * Enables or disables support for numeric IDs.
+         *
+         * @param enabled {@code true} to accept numeric IDs
+         * @return this builder
+         */
+        public Builder allowNumericId(boolean enabled) {
+            this.allowNumericId = enabled;
+            return this;
+        }
+
+        /**
+         * Enables or disables support for fractional numeric IDs.
+         *
+         * @param enabled {@code true} to accept fractional numbers (for example {@code 1.5})
+         * @return this builder
+         */
+        public Builder allowFractionalId(boolean enabled) {
+            this.allowFractionalId = enabled;
+            return this;
+        }
+
+        /**
+         * Enables or disables request rejection when response-only fields are present.
+         *
+         * @param enabled {@code true} to reject requests containing {@code result}/{@code error}
+         * @return this builder
+         */
+        public Builder rejectResponseFields(boolean enabled) {
+            this.rejectResponseFields = enabled;
+            return this;
+        }
+
+        /**
+         * Sets the error-code mapping policy used when {@code params} exists but is neither object nor array.
+         *
+         * @param policy params-type violation error-code policy
+         * @return this builder
+         */
+        public Builder paramsTypeViolationCodePolicy(JsonRpcParamsTypeViolationCodePolicy policy) {
+            this.paramsTypeViolationCodePolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        /**
+         * Builds immutable validation options.
+         *
+         * @return immutable request validation options
+         */
+        public JsonRpcRequestValidationOptions build() {
+            return new JsonRpcRequestValidationOptions(this);
+        }
+    }
+}

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcResponseErrorCodePolicy.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcResponseErrorCodePolicy.java
@@ -1,0 +1,27 @@
+package com.limehee.jsonrpc.core;
+
+/**
+ * Policy controlling accepted integer ranges for incoming response {@code error.code}.
+ */
+public enum JsonRpcResponseErrorCodePolicy {
+
+    /**
+     * Accept any integer.
+     */
+    ANY_INTEGER,
+
+    /**
+     * Accept only JSON-RPC standard error codes.
+     */
+    STANDARD_ONLY,
+
+    /**
+     * Accept standard error codes and server-error reserved range ({@code -32099..-32000}).
+     */
+    STANDARD_OR_SERVER_ERROR_RANGE,
+
+    /**
+     * Accept only values inside a user-defined custom range.
+     */
+    CUSTOM_RANGE
+}

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcResponseValidationOptions.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcResponseValidationOptions.java
@@ -1,41 +1,52 @@
 package com.limehee.jsonrpc.core;
 
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
 /**
  * Fine-grained validation switches for incoming JSON-RPC response validation.
  */
 public final class JsonRpcResponseValidationOptions {
 
     private final boolean requireJsonRpcVersion20;
-    private final boolean requireResponseIdMember;
-    private final boolean allowNullResponseId;
-    private final boolean allowStringResponseId;
-    private final boolean allowNumericResponseId;
-    private final boolean allowFractionalResponseId;
+    private final boolean requireIdMember;
+    private final boolean allowNullId;
+    private final boolean allowStringId;
+    private final boolean allowNumericId;
+    private final boolean allowFractionalId;
     private final boolean requireExclusiveResultOrError;
     private final boolean requireErrorObjectWhenPresent;
     private final boolean requireIntegerErrorCode;
     private final boolean requireStringErrorMessage;
-    private final boolean allowRequestFieldsInResponse;
+    private final boolean rejectRequestFields;
+    private final boolean rejectDuplicateMembers;
+    private final JsonRpcResponseErrorCodePolicy errorCodePolicy;
+    private final @Nullable Integer errorCodeRangeMin;
+    private final @Nullable Integer errorCodeRangeMax;
 
     private JsonRpcResponseValidationOptions(Builder builder) {
         this.requireJsonRpcVersion20 = builder.requireJsonRpcVersion20;
-        this.requireResponseIdMember = builder.requireResponseIdMember;
-        this.allowNullResponseId = builder.allowNullResponseId;
-        this.allowStringResponseId = builder.allowStringResponseId;
-        this.allowNumericResponseId = builder.allowNumericResponseId;
-        this.allowFractionalResponseId = builder.allowFractionalResponseId;
+        this.requireIdMember = builder.requireIdMember;
+        this.allowNullId = builder.allowNullId;
+        this.allowStringId = builder.allowStringId;
+        this.allowNumericId = builder.allowNumericId;
+        this.allowFractionalId = builder.allowFractionalId;
         this.requireExclusiveResultOrError = builder.requireExclusiveResultOrError;
         this.requireErrorObjectWhenPresent = builder.requireErrorObjectWhenPresent;
         this.requireIntegerErrorCode = builder.requireIntegerErrorCode;
         this.requireStringErrorMessage = builder.requireStringErrorMessage;
-        this.allowRequestFieldsInResponse = builder.allowRequestFieldsInResponse;
+        this.rejectRequestFields = builder.rejectRequestFields;
+        this.rejectDuplicateMembers = builder.rejectDuplicateMembers;
+        this.errorCodePolicy = builder.errorCodePolicy;
+        this.errorCodeRangeMin = builder.errorCodeRangeMin;
+        this.errorCodeRangeMax = builder.errorCodeRangeMax;
     }
 
     /**
      * Returns default validation options.
      * <p>
-     * RFC MUST rules are enabled by default. Compatibility-related rules are also configured with permissive defaults
-     * unless explicitly restricted through builder switches.
+     * RFC MUST rules are enabled by default. Optional interoperability-related rules stay permissive unless explicitly
+     * restricted via builder switches.
      *
      * @return default options
      */
@@ -62,36 +73,36 @@ public final class JsonRpcResponseValidationOptions {
     /**
      * @return whether the {@code id} member must exist
      */
-    public boolean requireResponseIdMember() {
-        return requireResponseIdMember;
+    public boolean requireIdMember() {
+        return requireIdMember;
     }
 
     /**
      * @return whether {@code id:null} is allowed
      */
-    public boolean allowNullResponseId() {
-        return allowNullResponseId;
+    public boolean allowNullId() {
+        return allowNullId;
     }
 
     /**
      * @return whether string IDs are allowed
      */
-    public boolean allowStringResponseId() {
-        return allowStringResponseId;
+    public boolean allowStringId() {
+        return allowStringId;
     }
 
     /**
      * @return whether numeric IDs are allowed
      */
-    public boolean allowNumericResponseId() {
-        return allowNumericResponseId;
+    public boolean allowNumericId() {
+        return allowNumericId;
     }
 
     /**
      * @return whether fractional numeric IDs are allowed
      */
-    public boolean allowFractionalResponseId() {
-        return allowFractionalResponseId;
+    public boolean allowFractionalId() {
+        return allowFractionalId;
     }
 
     /**
@@ -123,11 +134,38 @@ public final class JsonRpcResponseValidationOptions {
     }
 
     /**
-     * @return whether response objects may include request-only fields such as {@code method}/{@code params}; this is a
-     * compatibility policy and not an RFC MUST rule
+     * @return whether response objects containing request-only fields ({@code method}/{@code params}) are rejected
      */
-    public boolean allowRequestFieldsInResponse() {
-        return allowRequestFieldsInResponse;
+    public boolean rejectRequestFields() {
+        return rejectRequestFields;
+    }
+
+    /**
+     * @return whether response duplicate object members should be rejected during raw payload parsing
+     */
+    public boolean rejectDuplicateMembers() {
+        return rejectDuplicateMembers;
+    }
+
+    /**
+     * @return policy restricting accepted {@code error.code} integers
+     */
+    public JsonRpcResponseErrorCodePolicy errorCodePolicy() {
+        return errorCodePolicy;
+    }
+
+    /**
+     * @return lower bound for {@code error.code} when {@link #errorCodePolicy()} is {@code CUSTOM_RANGE}
+     */
+    public @Nullable Integer errorCodeRangeMin() {
+        return errorCodeRangeMin;
+    }
+
+    /**
+     * @return upper bound for {@code error.code} when {@link #errorCodePolicy()} is {@code CUSTOM_RANGE}
+     */
+    public @Nullable Integer errorCodeRangeMax() {
+        return errorCodeRangeMax;
     }
 
     /**
@@ -136,16 +174,20 @@ public final class JsonRpcResponseValidationOptions {
     public static final class Builder {
 
         private boolean requireJsonRpcVersion20 = true;
-        private boolean requireResponseIdMember = true;
-        private boolean allowNullResponseId = true;
-        private boolean allowStringResponseId = true;
-        private boolean allowNumericResponseId = true;
-        private boolean allowFractionalResponseId = true;
+        private boolean requireIdMember = true;
+        private boolean allowNullId = true;
+        private boolean allowStringId = true;
+        private boolean allowNumericId = true;
+        private boolean allowFractionalId = true;
         private boolean requireExclusiveResultOrError = true;
         private boolean requireErrorObjectWhenPresent = true;
         private boolean requireIntegerErrorCode = true;
         private boolean requireStringErrorMessage = true;
-        private boolean allowRequestFieldsInResponse = true;
+        private boolean rejectRequestFields = false;
+        private boolean rejectDuplicateMembers = false;
+        private JsonRpcResponseErrorCodePolicy errorCodePolicy = JsonRpcResponseErrorCodePolicy.ANY_INTEGER;
+        private @Nullable Integer errorCodeRangeMin;
+        private @Nullable Integer errorCodeRangeMax;
 
         private Builder() {
         }
@@ -167,8 +209,8 @@ public final class JsonRpcResponseValidationOptions {
          * @param enabled {@code true} to require an {@code id} member
          * @return this builder
          */
-        public Builder requireResponseIdMember(boolean enabled) {
-            this.requireResponseIdMember = enabled;
+        public Builder requireIdMember(boolean enabled) {
+            this.requireIdMember = enabled;
             return this;
         }
 
@@ -178,8 +220,8 @@ public final class JsonRpcResponseValidationOptions {
          * @param enabled {@code true} to accept null IDs
          * @return this builder
          */
-        public Builder allowNullResponseId(boolean enabled) {
-            this.allowNullResponseId = enabled;
+        public Builder allowNullId(boolean enabled) {
+            this.allowNullId = enabled;
             return this;
         }
 
@@ -189,8 +231,8 @@ public final class JsonRpcResponseValidationOptions {
          * @param enabled {@code true} to accept string IDs
          * @return this builder
          */
-        public Builder allowStringResponseId(boolean enabled) {
-            this.allowStringResponseId = enabled;
+        public Builder allowStringId(boolean enabled) {
+            this.allowStringId = enabled;
             return this;
         }
 
@@ -200,8 +242,8 @@ public final class JsonRpcResponseValidationOptions {
          * @param enabled {@code true} to accept numeric IDs
          * @return this builder
          */
-        public Builder allowNumericResponseId(boolean enabled) {
-            this.allowNumericResponseId = enabled;
+        public Builder allowNumericId(boolean enabled) {
+            this.allowNumericId = enabled;
             return this;
         }
 
@@ -211,8 +253,8 @@ public final class JsonRpcResponseValidationOptions {
          * @param enabled {@code true} to accept fractional numbers (for example {@code 1.5})
          * @return this builder
          */
-        public Builder allowFractionalResponseId(boolean enabled) {
-            this.allowFractionalResponseId = enabled;
+        public Builder allowFractionalId(boolean enabled) {
+            this.allowFractionalId = enabled;
             return this;
         }
 
@@ -261,13 +303,57 @@ public final class JsonRpcResponseValidationOptions {
         }
 
         /**
-         * Enables or disables tolerance for request-only fields in response objects.
+         * Enables or disables rejection for request-only fields in response objects.
          *
-         * @param enabled {@code true} to allow response objects containing {@code method}/{@code params}
+         * @param enabled {@code true} to reject response objects containing {@code method}/{@code params}
          * @return this builder
          */
-        public Builder allowRequestFieldsInResponse(boolean enabled) {
-            this.allowRequestFieldsInResponse = enabled;
+        public Builder rejectRequestFields(boolean enabled) {
+            this.rejectRequestFields = enabled;
+            return this;
+        }
+
+        /**
+         * Enables or disables duplicate member rejection in response payload parsing.
+         *
+         * @param enabled {@code true} to reject duplicate members while parsing raw response JSON
+         * @return this builder
+         */
+        public Builder rejectDuplicateMembers(boolean enabled) {
+            this.rejectDuplicateMembers = enabled;
+            return this;
+        }
+
+        /**
+         * Sets the accepted range policy for integer response {@code error.code} values.
+         *
+         * @param policy error-code policy
+         * @return this builder
+         */
+        public Builder errorCodePolicy(JsonRpcResponseErrorCodePolicy policy) {
+            this.errorCodePolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        /**
+         * Sets the lower bound for {@code error.code} when using {@code CUSTOM_RANGE}.
+         *
+         * @param min inclusive lower bound
+         * @return this builder
+         */
+        public Builder errorCodeRangeMin(@Nullable Integer min) {
+            this.errorCodeRangeMin = min;
+            return this;
+        }
+
+        /**
+         * Sets the upper bound for {@code error.code} when using {@code CUSTOM_RANGE}.
+         *
+         * @param max inclusive upper bound
+         * @return this builder
+         */
+        public Builder errorCodeRangeMax(@Nullable Integer max) {
+            this.errorCodeRangeMax = max;
             return this;
         }
 
@@ -277,6 +363,21 @@ public final class JsonRpcResponseValidationOptions {
          * @return immutable response validation options
          */
         public JsonRpcResponseValidationOptions build() {
+            if (!requireIntegerErrorCode && errorCodePolicy != JsonRpcResponseErrorCodePolicy.ANY_INTEGER) {
+                throw new IllegalArgumentException(
+                    "errorCodePolicy requires requireIntegerErrorCode=true when policy is not ANY_INTEGER"
+                );
+            }
+            if (errorCodePolicy == JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE) {
+                if (errorCodeRangeMin == null || errorCodeRangeMax == null) {
+                    throw new IllegalArgumentException(
+                        "CUSTOM_RANGE requires both errorCodeRangeMin and errorCodeRangeMax"
+                    );
+                }
+                if (errorCodeRangeMin > errorCodeRangeMax) {
+                    throw new IllegalArgumentException("errorCodeRangeMin must be less than or equal to errorCodeRangeMax");
+                }
+            }
             return new JsonRpcResponseValidationOptions(this);
         }
     }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcResponseValidationOptions.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcResponseValidationOptions.java
@@ -375,7 +375,8 @@ public final class JsonRpcResponseValidationOptions {
                     );
                 }
                 if (errorCodeRangeMin > errorCodeRangeMax) {
-                    throw new IllegalArgumentException("errorCodeRangeMin must be less than or equal to errorCodeRangeMax");
+                    throw new IllegalArgumentException(
+                        "errorCodeRangeMin must be less than or equal to errorCodeRangeMax");
                 }
             }
             return new JsonRpcResponseValidationOptions(this);

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidatorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidatorTest.java
@@ -31,6 +31,7 @@ class DefaultJsonRpcRequestValidatorTest {
 
         JsonRpcException ex = assertThrows(JsonRpcException.class, () -> validator.validate(request));
         assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+        assertEquals(JsonRpcConstants.MESSAGE_INVALID_REQUEST, ex.getMessage());
     }
 
     @Test

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidatorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidatorTest.java
@@ -14,6 +14,7 @@ import tools.jackson.databind.node.StringNode;
 class DefaultJsonRpcRequestValidatorTest {
 
     private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
+    private static final JsonRpcRequestParser REQUEST_PARSER = new DefaultJsonRpcRequestParser();
 
     private final DefaultJsonRpcRequestValidator validator = new DefaultJsonRpcRequestValidator();
 
@@ -30,6 +31,18 @@ class DefaultJsonRpcRequestValidatorTest {
 
         JsonRpcException ex = assertThrows(JsonRpcException.class, () -> validator.validate(request));
         assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateAllowsWrongProtocolVersionWhenDisabled() {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .requireJsonRpcVersion20(false)
+                .build()
+        );
+        JsonRpcRequest request = new JsonRpcRequest("1.0", IntNode.valueOf(1), "ping", null, true);
+
+        assertDoesNotThrow(() -> custom.validate(request));
     }
 
     @Test
@@ -51,6 +64,73 @@ class DefaultJsonRpcRequestValidatorTest {
         );
 
         JsonRpcException ex = assertThrows(JsonRpcException.class, () -> validator.validate(request));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateRejectsMissingIdWhenConfigured() {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .requireIdMember(true)
+                .build()
+        );
+
+        JsonRpcRequest request = new JsonRpcRequest("2.0", null, "ping", null, false);
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> custom.validate(request));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateRejectsNullIdWhenDisabled() {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .allowNullId(false)
+                .build()
+        );
+        JsonRpcRequest request = new JsonRpcRequest("2.0", NullNode.getInstance(), "ping", null, true);
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> custom.validate(request));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateRejectsStringIdWhenDisabled() {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .allowStringId(false)
+                .build()
+        );
+        JsonRpcRequest request = new JsonRpcRequest("2.0", StringNode.valueOf("abc"), "ping", null, true);
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> custom.validate(request));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateRejectsNumericIdWhenDisabled() {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .allowNumericId(false)
+                .build()
+        );
+        JsonRpcRequest request = new JsonRpcRequest("2.0", IntNode.valueOf(7), "ping", null, true);
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> custom.validate(request));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateRejectsFractionalIdWhenDisabled() throws Exception {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .allowFractionalId(false)
+                .build()
+        );
+        JsonRpcRequest request = REQUEST_PARSER.parse(OBJECT_MAPPER.readTree("""
+            {"jsonrpc":"2.0","method":"ping","id":1.5}
+            """));
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> custom.validate(request));
         assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
     }
 
@@ -77,7 +157,15 @@ class DefaultJsonRpcRequestValidatorTest {
     void constructorRejectsNullParamsTypeViolationPolicy() {
         assertThrows(
             NullPointerException.class,
-            () -> new DefaultJsonRpcRequestValidator(null)
+            () -> new DefaultJsonRpcRequestValidator((JsonRpcParamsTypeViolationCodePolicy) null)
+        );
+    }
+
+    @Test
+    void constructorRejectsNullOptions() {
+        assertThrows(
+            NullPointerException.class,
+            () -> new DefaultJsonRpcRequestValidator((JsonRpcRequestValidationOptions) null)
         );
     }
 
@@ -113,6 +201,29 @@ class DefaultJsonRpcRequestValidatorTest {
     @Test
     void validateAllowsNotificationWithoutId() {
         JsonRpcRequest request = new JsonRpcRequest("2.0", null, "ping", null, false);
+        assertDoesNotThrow(() -> validator.validate(request));
+    }
+
+    @Test
+    void validateRejectsRequestContainingResponseFieldsWhenConfigured() throws Exception {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .rejectResponseFields(true)
+                .build()
+        );
+        JsonRpcRequest request = REQUEST_PARSER.parse(OBJECT_MAPPER.readTree("""
+            {"jsonrpc":"2.0","method":"ping","id":1,"result":1}
+            """));
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> custom.validate(request));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateAllowsRequestContainingResponseFieldsByDefault() throws Exception {
+        JsonRpcRequest request = REQUEST_PARSER.parse(OBJECT_MAPPER.readTree("""
+            {"jsonrpc":"2.0","method":"ping","id":1,"result":1}
+            """));
         assertDoesNotThrow(() -> validator.validate(request));
     }
 }

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidatorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidatorTest.java
@@ -54,6 +54,14 @@ class DefaultJsonRpcRequestValidatorTest {
     }
 
     @Test
+    void validateRejectsReservedMethodNamespace() {
+        JsonRpcRequest request = new JsonRpcRequest("2.0", IntNode.valueOf(1), "rpc.system", null, true);
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> validator.validate(request));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
     void validateRejectsInvalidIdType() {
         JsonRpcRequest request = new JsonRpcRequest(
             "2.0",

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidatorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcRequestValidatorTest.java
@@ -143,6 +143,66 @@ class DefaultJsonRpcRequestValidatorTest {
     }
 
     @Test
+    void validateAllowsNullIdWhenOptionIsExplicitlyEnabled() {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .allowNullId(true)
+                .allowStringId(false)
+                .allowNumericId(false)
+                .build()
+        );
+        JsonRpcRequest request = new JsonRpcRequest("2.0", NullNode.getInstance(), "ping", null, true);
+
+        assertDoesNotThrow(() -> custom.validate(request));
+    }
+
+    @Test
+    void validateAllowsStringIdWhenOptionIsExplicitlyEnabled() {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .allowNullId(false)
+                .allowStringId(true)
+                .allowNumericId(false)
+                .build()
+        );
+        JsonRpcRequest request = new JsonRpcRequest("2.0", StringNode.valueOf("abc"), "ping", null, true);
+
+        assertDoesNotThrow(() -> custom.validate(request));
+    }
+
+    @Test
+    void validateAllowsNumericIdWhenOptionIsExplicitlyEnabled() {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .allowNullId(false)
+                .allowStringId(false)
+                .allowNumericId(true)
+                .allowFractionalId(false)
+                .build()
+        );
+        JsonRpcRequest request = new JsonRpcRequest("2.0", IntNode.valueOf(7), "ping", null, true);
+
+        assertDoesNotThrow(() -> custom.validate(request));
+    }
+
+    @Test
+    void validateAllowsFractionalIdWhenOptionIsExplicitlyEnabled() throws Exception {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .allowNullId(false)
+                .allowStringId(false)
+                .allowNumericId(true)
+                .allowFractionalId(true)
+                .build()
+        );
+        JsonRpcRequest request = REQUEST_PARSER.parse(OBJECT_MAPPER.readTree("""
+            {"jsonrpc":"2.0","method":"ping","id":1.5}
+            """));
+
+        assertDoesNotThrow(() -> custom.validate(request));
+    }
+
+    @Test
     void validateRejectsPrimitiveParams() {
         JsonRpcRequest request = new JsonRpcRequest("2.0", IntNode.valueOf(1), "ping", IntNode.valueOf(3), true);
 
@@ -225,6 +285,18 @@ class DefaultJsonRpcRequestValidatorTest {
 
         JsonRpcException ex = assertThrows(JsonRpcException.class, () -> custom.validate(request));
         assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateSkipsResponseFieldRejectionWhenSourceIsUnavailable() {
+        DefaultJsonRpcRequestValidator custom = new DefaultJsonRpcRequestValidator(
+            JsonRpcRequestValidationOptions.builder()
+                .rejectResponseFields(true)
+                .build()
+        );
+        JsonRpcRequest request = new JsonRpcRequest("2.0", IntNode.valueOf(1), "ping", null, true);
+
+        assertDoesNotThrow(() -> custom.validate(request));
     }
 
     @Test

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParserTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParserTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -98,6 +99,12 @@ class DefaultJsonRpcResponseParserTest {
     }
 
     @Test
+    void parseStringRejectsNullPayload() {
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> parser.parse((String) null));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
     void parseStringRejectsDuplicateMembersWhenEnabled() {
         DefaultJsonRpcResponseParser strictParser = new DefaultJsonRpcResponseParser(true);
 
@@ -120,6 +127,43 @@ class DefaultJsonRpcResponseParserTest {
     @Test
     void parseBytesRejectsMalformedJson() {
         JsonRpcException ex = assertThrows(JsonRpcException.class, () -> parser.parse("{".getBytes()));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void parseBytesParsesSingleResponseObject() {
+        JsonRpcIncomingResponseEnvelope envelope = parser.parse("""
+            {"jsonrpc":"2.0","id":1,"result":{"ok":true}}
+            """.getBytes(StandardCharsets.UTF_8));
+
+        assertFalse(envelope.isBatch());
+        JsonRpcIncomingResponse response = envelope.singleResponse().orElseThrow();
+        assertEquals(1, response.id().asInt());
+    }
+
+    @Test
+    void parseBytesRejectsDuplicateMembersWhenEnabled() {
+        DefaultJsonRpcResponseParser strictParser = new DefaultJsonRpcResponseParser(true);
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> strictParser.parse("""
+            {"jsonrpc":"2.0","id":1,"id":2,"result":1}
+            """.getBytes(StandardCharsets.UTF_8)));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void parseBytesAllowsDuplicateMembersWhenDisabled() {
+        JsonRpcIncomingResponseEnvelope envelope = parser.parse("""
+            {"jsonrpc":"2.0","id":1,"id":2,"result":1}
+            """.getBytes(StandardCharsets.UTF_8));
+
+        JsonRpcIncomingResponse response = envelope.singleResponse().orElseThrow();
+        assertEquals(2, response.id().asInt());
+    }
+
+    @Test
+    void parseBytesRejectsNullPayload() {
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> parser.parse((byte[]) null));
         assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
     }
 }

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParserTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseParserTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -14,7 +15,7 @@ class DefaultJsonRpcResponseParserTest {
 
     private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
-    private final JsonRpcResponseParser parser = new DefaultJsonRpcResponseParser();
+    private final DefaultJsonRpcResponseParser parser = new DefaultJsonRpcResponseParser();
 
     @Test
     void parseParsesSingleResponseObject() throws Exception {
@@ -67,7 +68,7 @@ class DefaultJsonRpcResponseParserTest {
 
     @Test
     void parseRejectsNullPayload() {
-        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> parser.parse(null));
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> parser.parse((JsonNode) null));
         assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
     }
 
@@ -78,5 +79,47 @@ class DefaultJsonRpcResponseParserTest {
         assertThrows(JsonRpcException.class, () -> parser.parse(OBJECT_MAPPER.readTree("""
             [{"jsonrpc":"2.0","id":1,"result":1}, 2]
             """)));
+    }
+
+    @Test
+    void parseStringParsesSingleResponseObject() {
+        JsonRpcIncomingResponseEnvelope envelope = parser.parse("""
+            {"jsonrpc":"2.0","id":1,"result":{"ok":true}}
+            """);
+
+        assertFalse(envelope.isBatch());
+        assertTrue(envelope.singleResponse().isPresent());
+    }
+
+    @Test
+    void parseStringRejectsMalformedJson() {
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> parser.parse("{"));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void parseStringRejectsDuplicateMembersWhenEnabled() {
+        DefaultJsonRpcResponseParser strictParser = new DefaultJsonRpcResponseParser(true);
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> strictParser.parse("""
+            {"jsonrpc":"2.0","id":1,"id":2,"result":1}
+            """));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void parseStringAllowsDuplicateMembersWhenDisabled() {
+        JsonRpcIncomingResponseEnvelope envelope = parser.parse("""
+            {"jsonrpc":"2.0","id":1,"id":2,"result":1}
+            """);
+
+        JsonRpcIncomingResponse response = envelope.singleResponse().orElseThrow();
+        assertEquals(2, response.id().asInt());
+    }
+
+    @Test
+    void parseBytesRejectsMalformedJson() {
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> parser.parse("{".getBytes()));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
     }
 }

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
@@ -69,7 +69,7 @@ class DefaultJsonRpcResponseValidatorTest {
     void validateAllowsMissingIdWhenRuleDisabled() throws Exception {
         JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
             JsonRpcResponseValidationOptions.builder()
-                .requireResponseIdMember(false)
+                .requireIdMember(false)
                 .build()
         );
 
@@ -89,21 +89,21 @@ class DefaultJsonRpcResponseValidatorTest {
     @Test
     void validateRespectsIdTypeOptions() throws Exception {
         JsonRpcResponseValidator noNull = new DefaultJsonRpcResponseValidator(
-            JsonRpcResponseValidationOptions.builder().allowNullResponseId(false).build()
+            JsonRpcResponseValidationOptions.builder().allowNullId(false).build()
         );
         assertThrows(JsonRpcException.class, () -> noNull.validate(incoming("""
             {"jsonrpc":"2.0","id":null,"result":1}
             """)));
 
         JsonRpcResponseValidator noString = new DefaultJsonRpcResponseValidator(
-            JsonRpcResponseValidationOptions.builder().allowStringResponseId(false).build()
+            JsonRpcResponseValidationOptions.builder().allowStringId(false).build()
         );
         assertThrows(JsonRpcException.class, () -> noString.validate(incoming("""
             {"jsonrpc":"2.0","id":"x","result":1}
             """)));
 
         JsonRpcResponseValidator noNumeric = new DefaultJsonRpcResponseValidator(
-            JsonRpcResponseValidationOptions.builder().allowNumericResponseId(false).build()
+            JsonRpcResponseValidationOptions.builder().allowNumericId(false).build()
         );
         assertThrows(JsonRpcException.class, () -> noNumeric.validate(incoming("""
             {"jsonrpc":"2.0","id":1,"result":1}
@@ -114,7 +114,7 @@ class DefaultJsonRpcResponseValidatorTest {
     void validateRejectsFractionalIdWhenDisabled() throws Exception {
         JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
             JsonRpcResponseValidationOptions.builder()
-                .allowFractionalResponseId(false)
+                .allowFractionalId(false)
                 .build()
         );
 
@@ -210,10 +210,10 @@ class DefaultJsonRpcResponseValidatorTest {
     }
 
     @Test
-    void validateCanRejectRequestFieldsWhenOptionDisabled() throws Exception {
+    void validateRejectsRequestFieldsWhenOptionEnabled() throws Exception {
         JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
             JsonRpcResponseValidationOptions.builder()
-                .allowRequestFieldsInResponse(false)
+                .rejectRequestFields(true)
                 .build()
         );
 
@@ -239,6 +239,64 @@ class DefaultJsonRpcResponseValidatorTest {
     @Test
     void constructorRejectsNullOptions() {
         assertThrows(NullPointerException.class, () -> new DefaultJsonRpcResponseValidator(null));
+    }
+
+    @Test
+    void validateRejectsNonStandardErrorCodeWhenPolicyIsStandardOnly() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .errorCodePolicy(JsonRpcResponseErrorCodePolicy.STANDARD_ONLY)
+                .build()
+        );
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"server"}}
+            """)));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateAllowsServerErrorRangeWhenPolicyConfigured() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .errorCodePolicy(JsonRpcResponseErrorCodePolicy.STANDARD_OR_SERVER_ERROR_RANGE)
+                .build()
+        );
+
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32050,"message":"server"}}
+            """)));
+    }
+
+    @Test
+    void validateRejectsOutOfRangeCustomErrorCode() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .errorCodePolicy(JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE)
+                .errorCodeRangeMin(-45000)
+                .errorCodeRangeMax(-44000)
+                .build()
+        );
+
+        JsonRpcException ex = assertThrows(JsonRpcException.class, () -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32050,"message":"server"}}
+            """)));
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+    }
+
+    @Test
+    void validateAllowsInRangeCustomErrorCode() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .errorCodePolicy(JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE)
+                .errorCodeRangeMin(-45000)
+                .errorCodeRangeMax(-44000)
+                .build()
+        );
+
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-44500,"message":"custom"}}
+            """)));
     }
 
     private JsonRpcIncomingResponse incoming(String json) throws Exception {

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
@@ -318,7 +318,6 @@ class DefaultJsonRpcResponseValidatorTest {
                 .build()
         );
         JsonRpcIncomingResponse response = new JsonRpcIncomingResponse(
-            null,
             "2.0",
             OBJECT_MAPPER.getNodeFactory().numberNode(1),
             true,

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
@@ -42,6 +42,7 @@ class DefaultJsonRpcResponseValidatorTest {
             {"jsonrpc":"1.0","id":1,"result":1}
             """)));
         assertEquals(JsonRpcErrorCode.INVALID_REQUEST, ex.getCode());
+        assertEquals(JsonRpcConstants.MESSAGE_INVALID_REQUEST, ex.getMessage());
     }
 
     @Test

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
@@ -124,6 +124,68 @@ class DefaultJsonRpcResponseValidatorTest {
     }
 
     @Test
+    void validateAllowsNullIdWhenOptionIsExplicitlyEnabled() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .allowNullId(true)
+                .allowStringId(false)
+                .allowNumericId(false)
+                .build()
+        );
+
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":null,"result":1}
+            """)));
+    }
+
+    @Test
+    void validateAllowsStringIdWhenOptionIsExplicitlyEnabled() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .allowNullId(false)
+                .allowStringId(true)
+                .allowNumericId(false)
+                .build()
+        );
+
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":"abc","result":1}
+            """)));
+    }
+
+    @Test
+    void validateAllowsNumericIdWhenOptionIsExplicitlyEnabled() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .allowNullId(false)
+                .allowStringId(false)
+                .allowNumericId(true)
+                .allowFractionalId(false)
+                .build()
+        );
+
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"result":1}
+            """)));
+    }
+
+    @Test
+    void validateAllowsFractionalIdWhenOptionIsExplicitlyEnabled() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .allowNullId(false)
+                .allowStringId(false)
+                .allowNumericId(true)
+                .allowFractionalId(true)
+                .build()
+        );
+
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1.5,"result":1}
+            """)));
+    }
+
+    @Test
     void validateRejectsInvalidResultAndErrorCombination() throws Exception {
         assertThrows(JsonRpcException.class, () -> validator.validate(incoming("""
             {"jsonrpc":"2.0","id":1,"result":1,"error":{"code":-32000,"message":"x"}}
@@ -210,6 +272,32 @@ class DefaultJsonRpcResponseValidatorTest {
     }
 
     @Test
+    void validateAllowsNonIntegerErrorCodeWhenIntegerRuleIsDisabled() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .requireIntegerErrorCode(false)
+                .build()
+        );
+
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":"x","message":"err"}}
+            """)));
+    }
+
+    @Test
+    void validateAllowsNonStringErrorMessageWhenStringRuleIsDisabled() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .requireStringErrorMessage(false)
+                .build()
+        );
+
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":3}}
+            """)));
+    }
+
+    @Test
     void validateRejectsRequestFieldsWhenOptionEnabled() throws Exception {
         JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
             JsonRpcResponseValidationOptions.builder()
@@ -220,6 +308,27 @@ class DefaultJsonRpcResponseValidatorTest {
         assertThrows(JsonRpcException.class, () -> custom.validate(incoming("""
             {"jsonrpc":"2.0","id":1,"result":1,"method":"ping"}
             """)));
+    }
+
+    @Test
+    void validateSkipsRequestFieldRejectionWhenSourceIsUnavailable() {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .rejectRequestFields(true)
+                .build()
+        );
+        JsonRpcIncomingResponse response = new JsonRpcIncomingResponse(
+            null,
+            "2.0",
+            OBJECT_MAPPER.getNodeFactory().numberNode(1),
+            true,
+            OBJECT_MAPPER.getNodeFactory().numberNode(1),
+            true,
+            null,
+            false
+        );
+
+        assertDoesNotThrow(() -> custom.validate(response));
     }
 
     @Test

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/DefaultJsonRpcResponseValidatorTest.java
@@ -269,6 +269,35 @@ class DefaultJsonRpcResponseValidatorTest {
     }
 
     @Test
+    void validateAllowsServerErrorRangeBoundariesWhenPolicyConfigured() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .errorCodePolicy(JsonRpcResponseErrorCodePolicy.STANDARD_OR_SERVER_ERROR_RANGE)
+                .build()
+        );
+
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"server"}}
+            """)));
+        assertDoesNotThrow(() -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"server"}}
+            """)));
+    }
+
+    @Test
+    void validateRejectsOutsideServerErrorRangeWhenPolicyConfigured() throws Exception {
+        JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
+            JsonRpcResponseValidationOptions.builder()
+                .errorCodePolicy(JsonRpcResponseErrorCodePolicy.STANDARD_OR_SERVER_ERROR_RANGE)
+                .build()
+        );
+
+        assertThrows(JsonRpcException.class, () -> custom.validate(incoming("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32100,"message":"server"}}
+            """)));
+    }
+
+    @Test
     void validateRejectsOutOfRangeCustomErrorCode() throws Exception {
         JsonRpcResponseValidator custom = new DefaultJsonRpcResponseValidator(
             JsonRpcResponseValidationOptions.builder()

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcDispatcherTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcDispatcherTest.java
@@ -475,6 +475,64 @@ class JsonRpcDispatcherTest {
     }
 
     @Test
+    void beforeValidateRuntimeExceptionIsMappedToInternalError() throws Exception {
+        JsonRpcInterceptor throwingInterceptor = new JsonRpcInterceptor() {
+            @Override
+            public void beforeValidate(JsonNode rawRequest) {
+                throw new IllegalStateException("beforeValidate boom");
+            }
+        };
+        JsonRpcDispatcher dispatcher = new JsonRpcDispatcher(
+            new InMemoryJsonRpcMethodRegistry(),
+            new DefaultJsonRpcRequestParser(),
+            new DefaultJsonRpcRequestValidator(),
+            new DefaultJsonRpcMethodInvoker(),
+            new DefaultJsonRpcExceptionResolver(),
+            new DefaultJsonRpcResponseComposer(),
+            100,
+            List.of(throwingInterceptor)
+        );
+        dispatcher.register("ping", params -> StringNode.valueOf("pong"));
+
+        JsonRpcDispatchResult result = dispatcher.dispatch(OBJECT_MAPPER.readTree("""
+            {"jsonrpc":"2.0","method":"ping","id":1}
+            """));
+
+        JsonRpcResponse response = result.singleResponse().orElseThrow();
+        assertEquals(JsonRpcErrorCode.INTERNAL_ERROR, response.error().code());
+        assertEquals(1, response.id().asInt());
+    }
+
+    @Test
+    void afterInvokeRuntimeExceptionIsMappedToInternalError() throws Exception {
+        JsonRpcInterceptor throwingInterceptor = new JsonRpcInterceptor() {
+            @Override
+            public void afterInvoke(JsonRpcRequest request, JsonNode result) {
+                throw new IllegalStateException("afterInvoke boom");
+            }
+        };
+        JsonRpcDispatcher dispatcher = new JsonRpcDispatcher(
+            new InMemoryJsonRpcMethodRegistry(),
+            new DefaultJsonRpcRequestParser(),
+            new DefaultJsonRpcRequestValidator(),
+            new DefaultJsonRpcMethodInvoker(),
+            new DefaultJsonRpcExceptionResolver(),
+            new DefaultJsonRpcResponseComposer(),
+            100,
+            List.of(throwingInterceptor)
+        );
+        dispatcher.register("ping", params -> StringNode.valueOf("pong"));
+
+        JsonRpcDispatchResult result = dispatcher.dispatch(OBJECT_MAPPER.readTree("""
+            {"jsonrpc":"2.0","method":"ping","id":2}
+            """));
+
+        JsonRpcResponse response = result.singleResponse().orElseThrow();
+        assertEquals(JsonRpcErrorCode.INTERNAL_ERROR, response.error().code());
+        assertEquals(2, response.id().asInt());
+    }
+
+    @Test
     void dispatchRequestPropagatesErrorFromHandler() throws Exception {
         JsonRpcDispatcher dispatcher = new JsonRpcDispatcher();
         dispatcher.register("fatal", params -> {

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcDispatcherTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcDispatcherTest.java
@@ -8,7 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
@@ -307,6 +310,28 @@ class JsonRpcDispatcherTest {
     }
 
     @Test
+    void dispatchRejectsReservedMethodNamespaceEvenWhenCustomRegistryAllowsIt() throws Exception {
+        JsonRpcDispatcher dispatcher = new JsonRpcDispatcher(
+            new PermissiveMethodRegistry(),
+            new DefaultJsonRpcRequestParser(),
+            new DefaultJsonRpcRequestValidator(),
+            new DefaultJsonRpcMethodInvoker(),
+            new DefaultJsonRpcExceptionResolver(),
+            new DefaultJsonRpcResponseComposer(),
+            100,
+            List.of()
+        );
+        dispatcher.register("rpc.system", params -> StringNode.valueOf("ok"));
+
+        JsonRpcDispatchResult result = dispatcher.dispatch(OBJECT_MAPPER.readTree("""
+            {"jsonrpc":"2.0","method":"rpc.system","id":1}
+            """));
+
+        JsonRpcResponse response = result.singleResponse().orElseThrow();
+        assertEquals(JsonRpcErrorCode.INVALID_REQUEST, response.error().code());
+    }
+
+    @Test
     void legacyDispatchMethodSupportsSingleRequest() {
         JsonRpcDispatcher dispatcher = new JsonRpcDispatcher();
         dispatcher.register("ping", params -> StringNode.valueOf("pong"));
@@ -485,6 +510,33 @@ class JsonRpcDispatcherTest {
             """)));
     }
 
+    @Test
+    void constructorRejectsNonPositiveMaxBatchSize() {
+        assertThrows(IllegalArgumentException.class, () -> new JsonRpcDispatcher(
+            new InMemoryJsonRpcMethodRegistry(),
+            new DefaultJsonRpcRequestParser(),
+            new DefaultJsonRpcRequestValidator(),
+            new DefaultJsonRpcMethodInvoker(),
+            new DefaultJsonRpcExceptionResolver(),
+            new DefaultJsonRpcResponseComposer(),
+            0,
+            List.of(),
+            new DirectJsonRpcNotificationExecutor()
+        ));
+
+        assertThrows(IllegalArgumentException.class, () -> new JsonRpcDispatcher(
+            new InMemoryJsonRpcMethodRegistry(),
+            new DefaultJsonRpcRequestParser(),
+            new DefaultJsonRpcRequestValidator(),
+            new DefaultJsonRpcMethodInvoker(),
+            new DefaultJsonRpcExceptionResolver(),
+            new DefaultJsonRpcResponseComposer(),
+            -1,
+            List.of(),
+            new DirectJsonRpcNotificationExecutor()
+        ));
+    }
+
     private static final class RecordingInterceptor implements JsonRpcInterceptor {
 
         private final List<String> events = new ArrayList<>();
@@ -518,6 +570,21 @@ class JsonRpcDispatcherTest {
         public void execute(Runnable task) {
             executeCount++;
             task.run();
+        }
+    }
+
+    private static final class PermissiveMethodRegistry implements JsonRpcMethodRegistry {
+
+        private final Map<String, JsonRpcMethodHandler> handlers = new HashMap<>();
+
+        @Override
+        public void register(String method, JsonRpcMethodHandler handler) {
+            handlers.put(method, handler);
+        }
+
+        @Override
+        public Optional<JsonRpcMethodHandler> find(String method) {
+            return Optional.ofNullable(handlers.get(method));
         }
     }
 }

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcIncomingResponseTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcIncomingResponseTest.java
@@ -1,7 +1,7 @@
 package com.limehee.jsonrpc.core;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcIncomingResponseTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcIncomingResponseTest.java
@@ -1,0 +1,51 @@
+package com.limehee.jsonrpc.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.IntNode;
+
+class JsonRpcIncomingResponseTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
+
+    @Test
+    void convenienceConstructorCreatesResponseWithoutSourceNode() {
+        JsonRpcIncomingResponse response = new JsonRpcIncomingResponse(
+            "2.0",
+            IntNode.valueOf(1),
+            true,
+            IntNode.valueOf(7),
+            true,
+            null,
+            false
+        );
+
+        assertNull(response.source());
+        assertTrue(response.idPresent());
+        assertTrue(response.resultPresent());
+        assertFalse(response.errorPresent());
+    }
+
+    @Test
+    void canonicalConstructorPreservesProvidedSourceNode() {
+        var source = OBJECT_MAPPER.createObjectNode().put("id", 1);
+        JsonRpcIncomingResponse response = new JsonRpcIncomingResponse(
+            source,
+            "2.0",
+            IntNode.valueOf(1),
+            true,
+            IntNode.valueOf(7),
+            true,
+            null,
+            false
+        );
+
+        assertEquals(1, response.source().get("id").asInt());
+    }
+}

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcPayloadReaderTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcPayloadReaderTest.java
@@ -36,7 +36,8 @@ class JsonRpcPayloadReaderTest {
 
         assertThrows(
             JacksonException.class,
-            () -> reader.readTree("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}".getBytes(StandardCharsets.UTF_8))
+            () -> reader.readTree(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}".getBytes(StandardCharsets.UTF_8))
         );
     }
 

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcPayloadReaderTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcPayloadReaderTest.java
@@ -1,0 +1,55 @@
+package com.limehee.jsonrpc.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class JsonRpcPayloadReaderTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
+
+    @Test
+    void readTreeFromStringRejectsDuplicateMembersWhenEnabled() {
+        JsonRpcPayloadReader reader = new JsonRpcPayloadReader(OBJECT_MAPPER, true);
+
+        assertThrows(
+            JacksonException.class,
+            () -> reader.readTree("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}")
+        );
+    }
+
+    @Test
+    void readTreeFromStringAcceptsDuplicateMembersWhenDisabled() throws Exception {
+        JsonRpcPayloadReader reader = new JsonRpcPayloadReader(OBJECT_MAPPER, false);
+
+        assertEquals(2, reader.readTree("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}").get("id").asInt());
+    }
+
+    @Test
+    void readTreeFromBytesRejectsDuplicateMembersWhenEnabled() {
+        JsonRpcPayloadReader reader = new JsonRpcPayloadReader(OBJECT_MAPPER, true);
+
+        assertThrows(
+            JacksonException.class,
+            () -> reader.readTree("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}".getBytes(StandardCharsets.UTF_8))
+        );
+    }
+
+    @Test
+    void readTreeFromBytesAcceptsDuplicateMembersWhenDisabled() throws Exception {
+        JsonRpcPayloadReader reader = new JsonRpcPayloadReader(OBJECT_MAPPER, false);
+
+        assertEquals(
+            2,
+            reader.readTree("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}".getBytes(StandardCharsets.UTF_8))
+                .get("id")
+                .asInt()
+        );
+    }
+}
+

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestValidationOptionsTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestValidationOptionsTest.java
@@ -19,6 +19,7 @@ class JsonRpcRequestValidationOptionsTest {
         assertTrue(options.allowNumericId());
         assertTrue(options.allowFractionalId());
         assertFalse(options.rejectResponseFields());
+        assertFalse(options.rejectDuplicateMembers());
         assertTrue(options.paramsTypeViolationCodePolicy() == JsonRpcParamsTypeViolationCodePolicy.INVALID_PARAMS);
     }
 
@@ -32,6 +33,7 @@ class JsonRpcRequestValidationOptionsTest {
             .allowNumericId(false)
             .allowFractionalId(false)
             .rejectResponseFields(true)
+            .rejectDuplicateMembers(true)
             .paramsTypeViolationCodePolicy(JsonRpcParamsTypeViolationCodePolicy.INVALID_REQUEST)
             .build();
 
@@ -42,6 +44,7 @@ class JsonRpcRequestValidationOptionsTest {
         assertFalse(options.allowNumericId());
         assertFalse(options.allowFractionalId());
         assertTrue(options.rejectResponseFields());
+        assertTrue(options.rejectDuplicateMembers());
         assertTrue(options.paramsTypeViolationCodePolicy() == JsonRpcParamsTypeViolationCodePolicy.INVALID_REQUEST);
     }
 

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestValidationOptionsTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestValidationOptionsTest.java
@@ -1,0 +1,55 @@
+package com.limehee.jsonrpc.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class JsonRpcRequestValidationOptionsTest {
+
+    @Test
+    void defaultsAlignWithJsonRpcRequestSemantics() {
+        JsonRpcRequestValidationOptions options = JsonRpcRequestValidationOptions.defaults();
+
+        assertTrue(options.requireJsonRpcVersion20());
+        assertFalse(options.requireIdMember());
+        assertTrue(options.allowNullId());
+        assertTrue(options.allowStringId());
+        assertTrue(options.allowNumericId());
+        assertTrue(options.allowFractionalId());
+        assertFalse(options.rejectResponseFields());
+        assertTrue(options.paramsTypeViolationCodePolicy() == JsonRpcParamsTypeViolationCodePolicy.INVALID_PARAMS);
+    }
+
+    @Test
+    void builderAllowsExplicitOverrides() {
+        JsonRpcRequestValidationOptions options = JsonRpcRequestValidationOptions.builder()
+            .requireJsonRpcVersion20(false)
+            .requireIdMember(true)
+            .allowNullId(false)
+            .allowStringId(false)
+            .allowNumericId(false)
+            .allowFractionalId(false)
+            .rejectResponseFields(true)
+            .paramsTypeViolationCodePolicy(JsonRpcParamsTypeViolationCodePolicy.INVALID_REQUEST)
+            .build();
+
+        assertFalse(options.requireJsonRpcVersion20());
+        assertTrue(options.requireIdMember());
+        assertFalse(options.allowNullId());
+        assertFalse(options.allowStringId());
+        assertFalse(options.allowNumericId());
+        assertFalse(options.allowFractionalId());
+        assertTrue(options.rejectResponseFields());
+        assertTrue(options.paramsTypeViolationCodePolicy() == JsonRpcParamsTypeViolationCodePolicy.INVALID_REQUEST);
+    }
+
+    @Test
+    void builderRejectsNullParamsTypeViolationPolicy() {
+        assertThrows(
+            NullPointerException.class,
+            () -> JsonRpcRequestValidationOptions.builder().paramsTypeViolationCodePolicy(null)
+        );
+    }
+}

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcResponseValidationOptionsTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcResponseValidationOptionsTest.java
@@ -1,6 +1,7 @@
 package com.limehee.jsonrpc.core;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -12,44 +13,95 @@ class JsonRpcResponseValidationOptionsTest {
         JsonRpcResponseValidationOptions options = JsonRpcResponseValidationOptions.defaults();
 
         assertTrue(options.requireJsonRpcVersion20());
-        assertTrue(options.requireResponseIdMember());
-        assertTrue(options.allowNullResponseId());
-        assertTrue(options.allowStringResponseId());
-        assertTrue(options.allowNumericResponseId());
-        assertTrue(options.allowFractionalResponseId());
+        assertTrue(options.requireIdMember());
+        assertTrue(options.allowNullId());
+        assertTrue(options.allowStringId());
+        assertTrue(options.allowNumericId());
+        assertTrue(options.allowFractionalId());
         assertTrue(options.requireExclusiveResultOrError());
         assertTrue(options.requireErrorObjectWhenPresent());
         assertTrue(options.requireIntegerErrorCode());
         assertTrue(options.requireStringErrorMessage());
-        assertTrue(options.allowRequestFieldsInResponse());
+        assertFalse(options.rejectRequestFields());
+        assertFalse(options.rejectDuplicateMembers());
+        assertTrue(options.errorCodePolicy() == JsonRpcResponseErrorCodePolicy.ANY_INTEGER);
     }
 
     @Test
     void builderAllowsOverridingEachFlag() {
         JsonRpcResponseValidationOptions options = JsonRpcResponseValidationOptions.builder()
             .requireJsonRpcVersion20(false)
-            .requireResponseIdMember(false)
-            .allowNullResponseId(false)
-            .allowStringResponseId(false)
-            .allowNumericResponseId(false)
-            .allowFractionalResponseId(false)
+            .requireIdMember(false)
+            .allowNullId(false)
+            .allowStringId(false)
+            .allowNumericId(false)
+            .allowFractionalId(false)
             .requireExclusiveResultOrError(false)
             .requireErrorObjectWhenPresent(false)
             .requireIntegerErrorCode(false)
             .requireStringErrorMessage(false)
-            .allowRequestFieldsInResponse(false)
+            .rejectRequestFields(true)
+            .rejectDuplicateMembers(true)
             .build();
 
         assertFalse(options.requireJsonRpcVersion20());
-        assertFalse(options.requireResponseIdMember());
-        assertFalse(options.allowNullResponseId());
-        assertFalse(options.allowStringResponseId());
-        assertFalse(options.allowNumericResponseId());
-        assertFalse(options.allowFractionalResponseId());
+        assertFalse(options.requireIdMember());
+        assertFalse(options.allowNullId());
+        assertFalse(options.allowStringId());
+        assertFalse(options.allowNumericId());
+        assertFalse(options.allowFractionalId());
         assertFalse(options.requireExclusiveResultOrError());
         assertFalse(options.requireErrorObjectWhenPresent());
         assertFalse(options.requireIntegerErrorCode());
         assertFalse(options.requireStringErrorMessage());
-        assertFalse(options.allowRequestFieldsInResponse());
+        assertTrue(options.rejectRequestFields());
+        assertTrue(options.rejectDuplicateMembers());
+    }
+
+    @Test
+    void builderRejectsIncompatibleErrorCodePolicyWhenIntegerCheckDisabled() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JsonRpcResponseValidationOptions.builder()
+                .requireIntegerErrorCode(false)
+                .errorCodePolicy(JsonRpcResponseErrorCodePolicy.STANDARD_ONLY)
+                .build()
+        );
+    }
+
+    @Test
+    void builderRejectsIncompleteCustomRange() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JsonRpcResponseValidationOptions.builder()
+                .errorCodePolicy(JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE)
+                .errorCodeRangeMin(-32603)
+                .build()
+        );
+    }
+
+    @Test
+    void builderRejectsInvertedCustomRange() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JsonRpcResponseValidationOptions.builder()
+                .errorCodePolicy(JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE)
+                .errorCodeRangeMin(-32000)
+                .errorCodeRangeMax(-32099)
+                .build()
+        );
+    }
+
+    @Test
+    void builderAcceptsCustomRangePolicy() {
+        JsonRpcResponseValidationOptions options = JsonRpcResponseValidationOptions.builder()
+            .errorCodePolicy(JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE)
+            .errorCodeRangeMin(-45000)
+            .errorCodeRangeMax(-44000)
+            .build();
+
+        assertTrue(options.errorCodePolicy() == JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE);
+        assertTrue(options.errorCodeRangeMin() == -45000);
+        assertTrue(options.errorCodeRangeMax() == -44000);
     }
 }

--- a/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
@@ -125,6 +125,7 @@ public class JsonRpcAutoConfiguration {
             .allowNumericId(request.isAllowNumericId())
             .allowFractionalId(request.isAllowFractionalId())
             .rejectResponseFields(request.isRejectResponseFields())
+            .rejectDuplicateMembers(request.isRejectDuplicateMembers())
             .paramsTypeViolationCodePolicy(request.getParamsTypeViolationCodePolicy())
             .build();
     }

--- a/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
@@ -4,8 +4,8 @@ import com.limehee.jsonrpc.core.DefaultJsonRpcExceptionResolver;
 import com.limehee.jsonrpc.core.DefaultJsonRpcMethodInvoker;
 import com.limehee.jsonrpc.core.DefaultJsonRpcRequestParser;
 import com.limehee.jsonrpc.core.DefaultJsonRpcRequestValidator;
-import com.limehee.jsonrpc.core.DefaultJsonRpcResponseParser;
 import com.limehee.jsonrpc.core.DefaultJsonRpcResponseComposer;
+import com.limehee.jsonrpc.core.DefaultJsonRpcResponseParser;
 import com.limehee.jsonrpc.core.DefaultJsonRpcResponseValidator;
 import com.limehee.jsonrpc.core.DefaultJsonRpcTypedMethodHandlerFactory;
 import com.limehee.jsonrpc.core.DirectJsonRpcNotificationExecutor;
@@ -24,8 +24,8 @@ import com.limehee.jsonrpc.core.JsonRpcParameterBinder;
 import com.limehee.jsonrpc.core.JsonRpcRequestParser;
 import com.limehee.jsonrpc.core.JsonRpcRequestValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcRequestValidator;
-import com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy;
 import com.limehee.jsonrpc.core.JsonRpcResponseComposer;
+import com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy;
 import com.limehee.jsonrpc.core.JsonRpcResponseParser;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidator;
@@ -502,12 +502,12 @@ public class JsonRpcAutoConfiguration {
     /**
      * Creates JSON-RPC WebMVC endpoint for servlet applications.
      *
-     * @param dispatcher           dispatcher handling JSON-RPC requests
-     * @param httpStatusStrategy   strategy mapping protocol outcomes to HTTP status codes
-     * @param objectMapperProvider provider for custom or default {@link ObjectMapper}
-     * @param webMvcObserver       observer for transport-level events
+     * @param dispatcher               dispatcher handling JSON-RPC requests
+     * @param httpStatusStrategy       strategy mapping protocol outcomes to HTTP status codes
+     * @param objectMapperProvider     provider for custom or default {@link ObjectMapper}
+     * @param webMvcObserver           observer for transport-level events
      * @param requestValidationOptions request-validation options
-     * @param properties           bound JSON-RPC properties
+     * @param properties               bound JSON-RPC properties
      * @return WebMVC endpoint bean
      */
     @Bean
@@ -608,7 +608,8 @@ public class JsonRpcAutoConfiguration {
         if (properties.getValidation().getResponse().getErrorCode().getRange() == null) {
             throw new IllegalArgumentException("jsonrpc.validation.response.error-code.range must not be null");
         }
-        JsonRpcResponseErrorCodePolicy errorCodePolicy = properties.getValidation().getResponse().getErrorCode().getPolicy();
+        JsonRpcResponseErrorCodePolicy errorCodePolicy = properties.getValidation().getResponse().getErrorCode()
+            .getPolicy();
         Integer errorCodeMin = properties.getValidation().getResponse().getErrorCode().getRange().getMin();
         Integer errorCodeMax = properties.getValidation().getResponse().getErrorCode().getRange().getMax();
         if (!properties.getValidation().getResponse().isRequireIntegerErrorCode()

--- a/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
@@ -4,6 +4,7 @@ import com.limehee.jsonrpc.core.DefaultJsonRpcExceptionResolver;
 import com.limehee.jsonrpc.core.DefaultJsonRpcMethodInvoker;
 import com.limehee.jsonrpc.core.DefaultJsonRpcRequestParser;
 import com.limehee.jsonrpc.core.DefaultJsonRpcRequestValidator;
+import com.limehee.jsonrpc.core.DefaultJsonRpcResponseParser;
 import com.limehee.jsonrpc.core.DefaultJsonRpcResponseComposer;
 import com.limehee.jsonrpc.core.DefaultJsonRpcResponseValidator;
 import com.limehee.jsonrpc.core.DefaultJsonRpcTypedMethodHandlerFactory;
@@ -25,6 +26,7 @@ import com.limehee.jsonrpc.core.JsonRpcRequestValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcRequestValidator;
 import com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy;
 import com.limehee.jsonrpc.core.JsonRpcResponseComposer;
+import com.limehee.jsonrpc.core.JsonRpcResponseParser;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidator;
 import com.limehee.jsonrpc.core.JsonRpcResultWriter;
@@ -184,6 +186,25 @@ public class JsonRpcAutoConfiguration {
             .errorCodeRangeMin(range.getMin())
             .errorCodeRangeMax(range.getMax())
             .build();
+    }
+
+    /**
+     * Creates parser for incoming JSON-RPC response envelopes.
+     *
+     * @param objectMapperProvider provider for custom or default {@link ObjectMapper}
+     * @param properties           bound JSON-RPC properties
+     * @return response parser
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public JsonRpcResponseParser jsonRpcResponseParser(
+        ObjectProvider<ObjectMapper> objectMapperProvider,
+        JsonRpcProperties properties
+    ) {
+        return new DefaultJsonRpcResponseParser(
+            objectMapperProvider.getIfAvailable(() -> JsonMapper.builder().build()),
+            properties.getValidation().getResponse().isRejectDuplicateMembers()
+        );
     }
 
     /**

--- a/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
@@ -193,18 +193,18 @@ public class JsonRpcAutoConfiguration {
      * Creates parser for incoming JSON-RPC response envelopes.
      *
      * @param objectMapperProvider provider for custom or default {@link ObjectMapper}
-     * @param properties           bound JSON-RPC properties
+     * @param options              response-validation options
      * @return response parser
      */
     @Bean
     @ConditionalOnMissingBean
     public JsonRpcResponseParser jsonRpcResponseParser(
         ObjectProvider<ObjectMapper> objectMapperProvider,
-        JsonRpcProperties properties
+        JsonRpcResponseValidationOptions options
     ) {
         return new DefaultJsonRpcResponseParser(
             objectMapperProvider.getIfAvailable(() -> JsonMapper.builder().build()),
-            properties.getValidation().getResponse().isRejectDuplicateMembers()
+            options.rejectDuplicateMembers()
         );
     }
 
@@ -506,6 +506,7 @@ public class JsonRpcAutoConfiguration {
      * @param httpStatusStrategy   strategy mapping protocol outcomes to HTTP status codes
      * @param objectMapperProvider provider for custom or default {@link ObjectMapper}
      * @param webMvcObserver       observer for transport-level events
+     * @param requestValidationOptions request-validation options
      * @param properties           bound JSON-RPC properties
      * @return WebMVC endpoint bean
      */
@@ -519,6 +520,7 @@ public class JsonRpcAutoConfiguration {
         JsonRpcHttpStatusStrategy httpStatusStrategy,
         ObjectProvider<ObjectMapper> objectMapperProvider,
         JsonRpcWebMvcObserver webMvcObserver,
+        JsonRpcRequestValidationOptions requestValidationOptions,
         JsonRpcProperties properties
     ) {
         ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(() -> JsonMapper.builder().build());
@@ -528,7 +530,7 @@ public class JsonRpcAutoConfiguration {
             httpStatusStrategy,
             properties.getMaxRequestBytes(),
             webMvcObserver,
-            properties.getValidation().getRequest().isRejectDuplicateMembers()
+            requestValidationOptions.rejectDuplicateMembers()
         );
     }
 

--- a/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfiguration.java
@@ -21,7 +21,9 @@ import com.limehee.jsonrpc.core.JsonRpcMethodRegistry;
 import com.limehee.jsonrpc.core.JsonRpcNotificationExecutor;
 import com.limehee.jsonrpc.core.JsonRpcParameterBinder;
 import com.limehee.jsonrpc.core.JsonRpcRequestParser;
+import com.limehee.jsonrpc.core.JsonRpcRequestValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcRequestValidator;
+import com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy;
 import com.limehee.jsonrpc.core.JsonRpcResponseComposer;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidator;
@@ -92,14 +94,14 @@ public class JsonRpcAutoConfiguration {
     }
 
     /**
-     * Creates request validator for JSON-RPC structural checks.
+     * Creates request-validation options bound from external configuration.
      *
      * @param properties bound JSON-RPC properties
-     * @return request validator
+     * @return request-validation options
      */
     @Bean
     @ConditionalOnMissingBean
-    public JsonRpcRequestValidator jsonRpcRequestValidator(JsonRpcProperties properties) {
+    public JsonRpcRequestValidationOptions jsonRpcRequestValidationOptions(JsonRpcProperties properties) {
         JsonRpcProperties.Validation validation = properties.getValidation();
         if (validation == null) {
             throw new IllegalArgumentException("jsonrpc.validation must not be null");
@@ -113,9 +115,28 @@ public class JsonRpcAutoConfiguration {
                 "jsonrpc.validation.request.params-type-violation-code-policy must not be null"
             );
         }
-        return new DefaultJsonRpcRequestValidator(
-            request.getParamsTypeViolationCodePolicy()
-        );
+        return JsonRpcRequestValidationOptions.builder()
+            .requireJsonRpcVersion20(request.isRequireJsonRpcVersion20())
+            .requireIdMember(request.isRequireIdMember())
+            .allowNullId(request.isAllowNullId())
+            .allowStringId(request.isAllowStringId())
+            .allowNumericId(request.isAllowNumericId())
+            .allowFractionalId(request.isAllowFractionalId())
+            .rejectResponseFields(request.isRejectResponseFields())
+            .paramsTypeViolationCodePolicy(request.getParamsTypeViolationCodePolicy())
+            .build();
+    }
+
+    /**
+     * Creates request validator for JSON-RPC structural checks.
+     *
+     * @param options request-validation options
+     * @return request validator
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public JsonRpcRequestValidator jsonRpcRequestValidator(JsonRpcRequestValidationOptions options) {
+        return new DefaultJsonRpcRequestValidator(options);
     }
 
     /**
@@ -135,18 +156,33 @@ public class JsonRpcAutoConfiguration {
         if (response == null) {
             throw new IllegalArgumentException("jsonrpc.validation.response must not be null");
         }
+        JsonRpcProperties.Validation.Response.ErrorCode errorCode = response.getErrorCode();
+        if (errorCode == null) {
+            throw new IllegalArgumentException("jsonrpc.validation.response.error-code must not be null");
+        }
+        if (errorCode.getPolicy() == null) {
+            throw new IllegalArgumentException("jsonrpc.validation.response.error-code.policy must not be null");
+        }
+        JsonRpcProperties.Validation.Response.ErrorCode.Range range = errorCode.getRange();
+        if (range == null) {
+            throw new IllegalArgumentException("jsonrpc.validation.response.error-code.range must not be null");
+        }
         return JsonRpcResponseValidationOptions.builder()
             .requireJsonRpcVersion20(response.isRequireJsonRpcVersion20())
-            .requireResponseIdMember(response.isRequireResponseIdMember())
-            .allowNullResponseId(response.isAllowNullResponseId())
-            .allowStringResponseId(response.isAllowStringResponseId())
-            .allowNumericResponseId(response.isAllowNumericResponseId())
-            .allowFractionalResponseId(response.isAllowFractionalResponseId())
+            .requireIdMember(response.isRequireIdMember())
+            .allowNullId(response.isAllowNullId())
+            .allowStringId(response.isAllowStringId())
+            .allowNumericId(response.isAllowNumericId())
+            .allowFractionalId(response.isAllowFractionalId())
             .requireExclusiveResultOrError(response.isRequireExclusiveResultOrError())
             .requireErrorObjectWhenPresent(response.isRequireErrorObjectWhenPresent())
             .requireIntegerErrorCode(response.isRequireIntegerErrorCode())
             .requireStringErrorMessage(response.isRequireStringErrorMessage())
-            .allowRequestFieldsInResponse(response.isAllowRequestFieldsInResponse())
+            .rejectRequestFields(response.isRejectRequestFields())
+            .rejectDuplicateMembers(response.isRejectDuplicateMembers())
+            .errorCodePolicy(errorCode.getPolicy())
+            .errorCodeRangeMin(range.getMin())
+            .errorCodeRangeMax(range.getMax())
             .build();
     }
 
@@ -469,7 +505,8 @@ public class JsonRpcAutoConfiguration {
             objectMapper,
             httpStatusStrategy,
             properties.getMaxRequestBytes(),
-            webMvcObserver
+            webMvcObserver,
+            properties.getValidation().getRequest().isRejectDuplicateMembers()
         );
     }
 
@@ -537,6 +574,36 @@ public class JsonRpcAutoConfiguration {
         }
         if (properties.getValidation().getResponse() == null) {
             throw new IllegalArgumentException("jsonrpc.validation.response must not be null");
+        }
+        if (properties.getValidation().getResponse().getErrorCode() == null) {
+            throw new IllegalArgumentException("jsonrpc.validation.response.error-code must not be null");
+        }
+        if (properties.getValidation().getResponse().getErrorCode().getPolicy() == null) {
+            throw new IllegalArgumentException("jsonrpc.validation.response.error-code.policy must not be null");
+        }
+        if (properties.getValidation().getResponse().getErrorCode().getRange() == null) {
+            throw new IllegalArgumentException("jsonrpc.validation.response.error-code.range must not be null");
+        }
+        JsonRpcResponseErrorCodePolicy errorCodePolicy = properties.getValidation().getResponse().getErrorCode().getPolicy();
+        Integer errorCodeMin = properties.getValidation().getResponse().getErrorCode().getRange().getMin();
+        Integer errorCodeMax = properties.getValidation().getResponse().getErrorCode().getRange().getMax();
+        if (!properties.getValidation().getResponse().isRequireIntegerErrorCode()
+            && errorCodePolicy != JsonRpcResponseErrorCodePolicy.ANY_INTEGER) {
+            throw new IllegalArgumentException(
+                "jsonrpc.validation.response.error-code.policy requires jsonrpc.validation.response.require-integer-error-code=true"
+            );
+        }
+        if (errorCodePolicy == JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE) {
+            if (errorCodeMin == null || errorCodeMax == null) {
+                throw new IllegalArgumentException(
+                    "jsonrpc.validation.response.error-code.range.min and range.max are required for CUSTOM_RANGE"
+                );
+            }
+            if (errorCodeMin > errorCodeMax) {
+                throw new IllegalArgumentException(
+                    "jsonrpc.validation.response.error-code.range.min must be less than or equal to range.max"
+                );
+            }
         }
 
         validateMethodList("jsonrpc.method-allowlist", properties.getMethodAllowlist());

--- a/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcProperties.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcProperties.java
@@ -2,9 +2,11 @@ package com.limehee.jsonrpc.spring.boot.autoconfigure;
 
 import com.limehee.jsonrpc.core.JsonRpcMethodRegistrationConflictPolicy;
 import com.limehee.jsonrpc.core.JsonRpcParamsTypeViolationCodePolicy;
+import com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -378,8 +380,160 @@ public class JsonRpcProperties {
          */
         public static final class Request {
 
+            private boolean requireJsonRpcVersion20 = true;
+            private boolean requireIdMember = false;
+            private boolean allowNullId = true;
+            private boolean allowStringId = true;
+            private boolean allowNumericId = true;
+            private boolean allowFractionalId = true;
+            private boolean rejectResponseFields = false;
+            private boolean rejectDuplicateMembers = false;
             private JsonRpcParamsTypeViolationCodePolicy paramsTypeViolationCodePolicy =
                 JsonRpcParamsTypeViolationCodePolicy.INVALID_PARAMS;
+
+            /**
+             * Indicates whether {@code jsonrpc == "2.0"} is required on incoming requests.
+             *
+             * @return {@code true} when version enforcement is enabled
+             */
+            public boolean isRequireJsonRpcVersion20() {
+                return requireJsonRpcVersion20;
+            }
+
+            /**
+             * Sets whether {@code jsonrpc == "2.0"} is required on incoming requests.
+             *
+             * @param requireJsonRpcVersion20 {@code true} to enforce version field
+             */
+            public void setRequireJsonRpcVersion20(boolean requireJsonRpcVersion20) {
+                this.requireJsonRpcVersion20 = requireJsonRpcVersion20;
+            }
+
+            /**
+             * Indicates whether incoming requests must include an {@code id} member.
+             *
+             * @return {@code true} when request {@code id} member is required
+             */
+            public boolean isRequireIdMember() {
+                return requireIdMember;
+            }
+
+            /**
+             * Sets whether incoming requests must include an {@code id} member.
+             *
+             * @param requireIdMember {@code true} to require request {@code id}
+             */
+            public void setRequireIdMember(boolean requireIdMember) {
+                this.requireIdMember = requireIdMember;
+            }
+
+            /**
+             * Indicates whether {@code id: null} is allowed in incoming requests.
+             *
+             * @return {@code true} when null IDs are accepted
+             */
+            public boolean isAllowNullId() {
+                return allowNullId;
+            }
+
+            /**
+             * Sets whether {@code id: null} is allowed in incoming requests.
+             *
+             * @param allowNullId {@code true} to accept null IDs
+             */
+            public void setAllowNullId(boolean allowNullId) {
+                this.allowNullId = allowNullId;
+            }
+
+            /**
+             * Indicates whether textual request IDs are allowed.
+             *
+             * @return {@code true} when string IDs are accepted
+             */
+            public boolean isAllowStringId() {
+                return allowStringId;
+            }
+
+            /**
+             * Sets whether textual request IDs are allowed.
+             *
+             * @param allowStringId {@code true} to accept string IDs
+             */
+            public void setAllowStringId(boolean allowStringId) {
+                this.allowStringId = allowStringId;
+            }
+
+            /**
+             * Indicates whether numeric request IDs are allowed.
+             *
+             * @return {@code true} when numeric IDs are accepted
+             */
+            public boolean isAllowNumericId() {
+                return allowNumericId;
+            }
+
+            /**
+             * Sets whether numeric request IDs are allowed.
+             *
+             * @param allowNumericId {@code true} to accept numeric IDs
+             */
+            public void setAllowNumericId(boolean allowNumericId) {
+                this.allowNumericId = allowNumericId;
+            }
+
+            /**
+             * Indicates whether fractional numeric request IDs are allowed.
+             *
+             * @return {@code true} when fractional numeric IDs are accepted
+             */
+            public boolean isAllowFractionalId() {
+                return allowFractionalId;
+            }
+
+            /**
+             * Sets whether fractional numeric request IDs are allowed.
+             *
+             * @param allowFractionalId {@code true} to accept fractional numeric IDs
+             */
+            public void setAllowFractionalId(boolean allowFractionalId) {
+                this.allowFractionalId = allowFractionalId;
+            }
+
+            /**
+             * Indicates whether response-only fields ({@code result}/{@code error}) are rejected in request payloads.
+             *
+             * @return {@code true} when response fields in requests are rejected
+             */
+            public boolean isRejectResponseFields() {
+                return rejectResponseFields;
+            }
+
+            /**
+             * Sets whether response-only fields ({@code result}/{@code error}) are rejected in request payloads.
+             *
+             * @param rejectResponseFields {@code true} to reject response-only fields in requests
+             */
+            public void setRejectResponseFields(boolean rejectResponseFields) {
+                this.rejectResponseFields = rejectResponseFields;
+            }
+
+            /**
+             * Indicates whether duplicate members are rejected in request payload parsing.
+             *
+             * @return {@code true} when duplicate members are rejected
+             */
+            public boolean isRejectDuplicateMembers() {
+                return rejectDuplicateMembers;
+            }
+
+            /**
+             * Sets whether duplicate members are rejected in request payload parsing.
+             *
+             * @param rejectDuplicateMembers {@code true} to reject duplicate members
+             */
+            public void setRejectDuplicateMembers(boolean rejectDuplicateMembers) {
+                this.rejectDuplicateMembers = rejectDuplicateMembers;
+            }
 
             /**
              * Returns the error-code mapping policy used when request {@code params} exists but is neither an object
@@ -413,16 +567,18 @@ public class JsonRpcProperties {
         public static final class Response {
 
             private boolean requireJsonRpcVersion20 = true;
-            private boolean requireResponseIdMember = true;
-            private boolean allowNullResponseId = true;
-            private boolean allowStringResponseId = true;
-            private boolean allowNumericResponseId = true;
-            private boolean allowFractionalResponseId = true;
+            private boolean requireIdMember = true;
+            private boolean allowNullId = true;
+            private boolean allowStringId = true;
+            private boolean allowNumericId = true;
+            private boolean allowFractionalId = true;
             private boolean requireExclusiveResultOrError = true;
             private boolean requireErrorObjectWhenPresent = true;
             private boolean requireIntegerErrorCode = true;
             private boolean requireStringErrorMessage = true;
-            private boolean allowRequestFieldsInResponse = true;
+            private boolean rejectRequestFields = false;
+            private boolean rejectDuplicateMembers = false;
+            private ErrorCode errorCode = new ErrorCode();
 
             /**
              * Indicates whether {@code jsonrpc == "2.0"} is required on incoming responses.
@@ -447,17 +603,17 @@ public class JsonRpcProperties {
              *
              * @return {@code true} when response {@code id} member is required
              */
-            public boolean isRequireResponseIdMember() {
-                return requireResponseIdMember;
+            public boolean isRequireIdMember() {
+                return requireIdMember;
             }
 
             /**
              * Sets whether incoming responses must include an {@code id} member.
              *
-             * @param requireResponseIdMember {@code true} to require response {@code id}
+             * @param requireIdMember {@code true} to require response {@code id}
              */
-            public void setRequireResponseIdMember(boolean requireResponseIdMember) {
-                this.requireResponseIdMember = requireResponseIdMember;
+            public void setRequireIdMember(boolean requireIdMember) {
+                this.requireIdMember = requireIdMember;
             }
 
             /**
@@ -465,17 +621,17 @@ public class JsonRpcProperties {
              *
              * @return {@code true} when null IDs are accepted
              */
-            public boolean isAllowNullResponseId() {
-                return allowNullResponseId;
+            public boolean isAllowNullId() {
+                return allowNullId;
             }
 
             /**
              * Sets whether {@code id: null} is allowed in incoming responses.
              *
-             * @param allowNullResponseId {@code true} to accept null IDs
+             * @param allowNullId {@code true} to accept null IDs
              */
-            public void setAllowNullResponseId(boolean allowNullResponseId) {
-                this.allowNullResponseId = allowNullResponseId;
+            public void setAllowNullId(boolean allowNullId) {
+                this.allowNullId = allowNullId;
             }
 
             /**
@@ -483,17 +639,17 @@ public class JsonRpcProperties {
              *
              * @return {@code true} when string IDs are accepted
              */
-            public boolean isAllowStringResponseId() {
-                return allowStringResponseId;
+            public boolean isAllowStringId() {
+                return allowStringId;
             }
 
             /**
              * Sets whether textual response IDs are allowed.
              *
-             * @param allowStringResponseId {@code true} to accept string IDs
+             * @param allowStringId {@code true} to accept string IDs
              */
-            public void setAllowStringResponseId(boolean allowStringResponseId) {
-                this.allowStringResponseId = allowStringResponseId;
+            public void setAllowStringId(boolean allowStringId) {
+                this.allowStringId = allowStringId;
             }
 
             /**
@@ -501,17 +657,17 @@ public class JsonRpcProperties {
              *
              * @return {@code true} when numeric IDs are accepted
              */
-            public boolean isAllowNumericResponseId() {
-                return allowNumericResponseId;
+            public boolean isAllowNumericId() {
+                return allowNumericId;
             }
 
             /**
              * Sets whether numeric response IDs are allowed.
              *
-             * @param allowNumericResponseId {@code true} to accept numeric IDs
+             * @param allowNumericId {@code true} to accept numeric IDs
              */
-            public void setAllowNumericResponseId(boolean allowNumericResponseId) {
-                this.allowNumericResponseId = allowNumericResponseId;
+            public void setAllowNumericId(boolean allowNumericId) {
+                this.allowNumericId = allowNumericId;
             }
 
             /**
@@ -519,17 +675,17 @@ public class JsonRpcProperties {
              *
              * @return {@code true} when fractional numeric IDs are accepted
              */
-            public boolean isAllowFractionalResponseId() {
-                return allowFractionalResponseId;
+            public boolean isAllowFractionalId() {
+                return allowFractionalId;
             }
 
             /**
              * Sets whether fractional numeric response IDs are allowed.
              *
-             * @param allowFractionalResponseId {@code true} to accept fractional numeric IDs
+             * @param allowFractionalId {@code true} to accept fractional numeric IDs
              */
-            public void setAllowFractionalResponseId(boolean allowFractionalResponseId) {
-                this.allowFractionalResponseId = allowFractionalResponseId;
+            public void setAllowFractionalId(boolean allowFractionalId) {
+                this.allowFractionalId = allowFractionalId;
             }
 
             /**
@@ -605,22 +761,148 @@ public class JsonRpcProperties {
             }
 
             /**
-             * Indicates whether request-only fields like {@code method}/{@code params} are allowed in response
+             * Indicates whether request-only fields like {@code method}/{@code params} are rejected in response
              * objects.
              *
-             * @return {@code true} when request fields are tolerated in responses
+             * @return {@code true} when request fields are rejected in responses
              */
-            public boolean isAllowRequestFieldsInResponse() {
-                return allowRequestFieldsInResponse;
+            public boolean isRejectRequestFields() {
+                return rejectRequestFields;
             }
 
             /**
-             * Sets whether request-only fields like {@code method}/{@code params} are allowed in response objects.
+             * Sets whether request-only fields like {@code method}/{@code params} are rejected in response objects.
              *
-             * @param allowRequestFieldsInResponse {@code true} to allow request fields in response
+             * @param rejectRequestFields {@code true} to reject request fields in response
              */
-            public void setAllowRequestFieldsInResponse(boolean allowRequestFieldsInResponse) {
-                this.allowRequestFieldsInResponse = allowRequestFieldsInResponse;
+            public void setRejectRequestFields(boolean rejectRequestFields) {
+                this.rejectRequestFields = rejectRequestFields;
+            }
+
+            /**
+             * Indicates whether duplicate members are rejected in response payload parsing.
+             *
+             * @return {@code true} when duplicate members are rejected
+             */
+            public boolean isRejectDuplicateMembers() {
+                return rejectDuplicateMembers;
+            }
+
+            /**
+             * Sets whether duplicate members are rejected in response payload parsing.
+             *
+             * @param rejectDuplicateMembers {@code true} to reject duplicate members
+             */
+            public void setRejectDuplicateMembers(boolean rejectDuplicateMembers) {
+                this.rejectDuplicateMembers = rejectDuplicateMembers;
+            }
+
+            /**
+             * Returns response error-code validation settings under {@code jsonrpc.validation.response.error-code.*}.
+             *
+             * @return response error-code settings
+             */
+            public ErrorCode getErrorCode() {
+                return errorCode;
+            }
+
+            /**
+             * Sets response error-code validation settings under {@code jsonrpc.validation.response.error-code.*}.
+             *
+             * @param errorCode response error-code settings; must not be {@code null}
+             */
+            public void setErrorCode(ErrorCode errorCode) {
+                this.errorCode = Objects.requireNonNull(errorCode, "errorCode");
+            }
+
+            /**
+             * Response error-code validation settings.
+             */
+            public static final class ErrorCode {
+
+                private JsonRpcResponseErrorCodePolicy policy = JsonRpcResponseErrorCodePolicy.ANY_INTEGER;
+                private Range range = new Range();
+
+                /**
+                 * Returns accepted error-code policy.
+                 *
+                 * @return error-code policy
+                 */
+                public JsonRpcResponseErrorCodePolicy getPolicy() {
+                    return policy;
+                }
+
+                /**
+                 * Sets accepted error-code policy.
+                 *
+                 * @param policy error-code policy
+                 */
+                public void setPolicy(JsonRpcResponseErrorCodePolicy policy) {
+                    this.policy = Objects.requireNonNull(policy, "policy");
+                }
+
+                /**
+                 * Returns custom range configuration for {@code CUSTOM_RANGE} policy.
+                 *
+                 * @return custom range configuration
+                 */
+                public Range getRange() {
+                    return range;
+                }
+
+                /**
+                 * Sets custom range configuration for {@code CUSTOM_RANGE} policy.
+                 *
+                 * @param range custom range configuration; must not be {@code null}
+                 */
+                public void setRange(Range range) {
+                    this.range = Objects.requireNonNull(range, "range");
+                }
+
+                /**
+                 * Range configuration for custom response error-code policy.
+                 */
+                public static final class Range {
+
+                    private @Nullable Integer min;
+                    private @Nullable Integer max;
+
+                    /**
+                     * Returns inclusive minimum of allowed error-code range.
+                     *
+                     * @return inclusive minimum, or {@code null} when unspecified
+                     */
+                    public @Nullable Integer getMin() {
+                        return min;
+                    }
+
+                    /**
+                     * Sets inclusive minimum of allowed error-code range.
+                     *
+                     * @param min inclusive minimum, or {@code null} when unspecified
+                     */
+                    public void setMin(@Nullable Integer min) {
+                        this.min = min;
+                    }
+
+                    /**
+                     * Returns inclusive maximum of allowed error-code range.
+                     *
+                     * @return inclusive maximum, or {@code null} when unspecified
+                     */
+                    public @Nullable Integer getMax() {
+                        return max;
+                    }
+
+                    /**
+                     * Sets inclusive maximum of allowed error-code range.
+                     *
+                     * @param max inclusive maximum, or {@code null} when unspecified
+                     */
+                    public void setMax(@Nullable Integer max) {
+                        this.max = max;
+                    }
+                }
             }
         }
     }

--- a/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/support/JsonRpcMetricsInterceptor.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/support/JsonRpcMetricsInterceptor.java
@@ -67,7 +67,8 @@ public final class JsonRpcMetricsInterceptor implements JsonRpcInterceptor {
      * @param latencyHistogramEnabled whether latency histogram buckets should be emitted
      * @param latencyPercentiles      latency percentiles to publish for timers
      * @param maxMethodTagValues      maximum number of distinct method tag values before collapsing to {@code other};
-     *                                values less than or equal to zero disable collapsing
+     *                                must be greater than {@code 0}
+     * @throws IllegalArgumentException if {@code maxMethodTagValues <= 0}
      */
     public JsonRpcMetricsInterceptor(
         MeterRegistry meterRegistry,
@@ -78,6 +79,9 @@ public final class JsonRpcMetricsInterceptor implements JsonRpcInterceptor {
         this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry");
         this.latencyHistogramEnabled = latencyHistogramEnabled;
         this.latencyPercentiles = Objects.requireNonNull(latencyPercentiles, "latencyPercentiles").clone();
+        if (maxMethodTagValues <= 0) {
+            throw new IllegalArgumentException("maxMethodTagValues must be greater than 0");
+        }
         this.maxMethodTagValues = maxMethodTagValues;
     }
 
@@ -264,9 +268,6 @@ public final class JsonRpcMetricsInterceptor implements JsonRpcInterceptor {
     private String normalizeMethodName(@Nullable String method) {
         if (method == null || method.isBlank()) {
             return METHOD_UNKNOWN;
-        }
-        if (maxMethodTagValues <= 0) {
-            return method;
         }
         if (seenMethods.contains(method)) {
             return method;

--- a/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/support/JsonRpcMetricsInterceptor.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/java/com/limehee/jsonrpc/spring/boot/autoconfigure/support/JsonRpcMetricsInterceptor.java
@@ -28,7 +28,8 @@ import tools.jackson.databind.JsonNode;
  * </ul>
  * <p>
  * Method tag cardinality can be bounded by {@code maxMethodTagValues}; once the limit is reached,
- * unseen methods are collapsed into the {@code other} bucket.
+ * unseen methods are collapsed into the {@code other} bucket. This limit is treated as a hard cap even when
+ * requests are processed concurrently.
  * </p>
  */
 public final class JsonRpcMetricsInterceptor implements JsonRpcInterceptor {
@@ -44,6 +45,7 @@ public final class JsonRpcMetricsInterceptor implements JsonRpcInterceptor {
     private final boolean latencyHistogramEnabled;
     private final double[] latencyPercentiles;
     private final int maxMethodTagValues;
+    private final Object methodTagLock = new Object();
     private final Set<String> seenMethods = ConcurrentHashMap.newKeySet();
     private final ConcurrentHashMap<CounterKey, Counter> callCounters = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<CounterKey, Counter> stageCounters = new ConcurrentHashMap<>();
@@ -263,7 +265,7 @@ public final class JsonRpcMetricsInterceptor implements JsonRpcInterceptor {
      * Applies method tag normalization and cardinality limiting.
      *
      * @param method raw method name from request
-     * @return normalized method tag value
+     * @return normalized method tag value, with strict cap enforcement for distinct method tags
      */
     private String normalizeMethodName(@Nullable String method) {
         if (method == null || method.isBlank()) {
@@ -272,13 +274,17 @@ public final class JsonRpcMetricsInterceptor implements JsonRpcInterceptor {
         if (seenMethods.contains(method)) {
             return method;
         }
-        if (seenMethods.size() >= maxMethodTagValues) {
-            return METHOD_OTHER;
-        }
-        if (seenMethods.add(method)) {
+
+        synchronized (methodTagLock) {
+            if (seenMethods.contains(method)) {
+                return method;
+            }
+            if (seenMethods.size() >= maxMethodTagValues) {
+                return METHOD_OTHER;
+            }
+            seenMethods.add(method);
             return method;
         }
-        return method;
     }
 
     /**

--- a/jsonrpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -51,6 +51,7 @@
     {
       "name": "jsonrpc.metrics-latency-percentiles",
       "type": "java.util.List<java.lang.Double>",
+      "defaultValue": [],
       "description": "Optional latency percentiles to publish (each value must be between 0.0 and 1.0, exclusive)."
     },
     {
@@ -222,11 +223,13 @@
     {
       "name": "jsonrpc.method-allowlist",
       "type": "java.util.List<java.lang.String>",
+      "defaultValue": [],
       "description": "Allowed JSON-RPC method names. Empty list means allow all. Blank entries are invalid."
     },
     {
       "name": "jsonrpc.method-denylist",
       "type": "java.util.List<java.lang.String>",
+      "defaultValue": [],
       "description": "Denied JSON-RPC method names. Denylist takes precedence over allowlist membership. Blank entries are invalid."
     }
   ],
@@ -278,6 +281,28 @@
         },
         {
           "value": "CUSTOM_RANGE"
+        }
+      ]
+    },
+    {
+      "name": "jsonrpc.validation.response.error-code.range.min",
+      "values": [
+        {
+          "value": -32099
+        },
+        {
+          "value": -32603
+        }
+      ]
+    },
+    {
+      "name": "jsonrpc.validation.response.error-code.range.max",
+      "values": [
+        {
+          "value": -32000
+        },
+        {
+          "value": -32001
         }
       ]
     },

--- a/jsonrpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/jsonrpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -78,6 +78,54 @@
       "description": "Policy used when a method name is registered more than once."
     },
     {
+      "name": "jsonrpc.validation.request.require-json-rpc-version-20",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Require incoming request jsonrpc to equal \"2.0\"."
+    },
+    {
+      "name": "jsonrpc.validation.request.require-id-member",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Require incoming requests to include an id member."
+    },
+    {
+      "name": "jsonrpc.validation.request.allow-null-id",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Allow id:null in incoming requests."
+    },
+    {
+      "name": "jsonrpc.validation.request.allow-string-id",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Allow string ids in incoming requests."
+    },
+    {
+      "name": "jsonrpc.validation.request.allow-numeric-id",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Allow numeric ids in incoming requests."
+    },
+    {
+      "name": "jsonrpc.validation.request.allow-fractional-id",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Allow fractional numeric ids in incoming requests."
+    },
+    {
+      "name": "jsonrpc.validation.request.reject-response-fields",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Reject request objects containing response-only fields (result/error)."
+    },
+    {
+      "name": "jsonrpc.validation.request.reject-duplicate-members",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Reject duplicate members when parsing raw JSON request payloads."
+    },
+    {
       "name": "jsonrpc.validation.request.params-type-violation-code-policy",
       "type": "com.limehee.jsonrpc.core.JsonRpcParamsTypeViolationCodePolicy",
       "defaultValue": "INVALID_PARAMS",
@@ -90,31 +138,31 @@
       "description": "Require incoming response jsonrpc to equal \"2.0\"."
     },
     {
-      "name": "jsonrpc.validation.response.require-response-id-member",
+      "name": "jsonrpc.validation.response.require-id-member",
       "type": "java.lang.Boolean",
       "defaultValue": true,
       "description": "Require incoming responses to include an id member."
     },
     {
-      "name": "jsonrpc.validation.response.allow-null-response-id",
+      "name": "jsonrpc.validation.response.allow-null-id",
       "type": "java.lang.Boolean",
       "defaultValue": true,
       "description": "Allow id:null in incoming responses."
     },
     {
-      "name": "jsonrpc.validation.response.allow-string-response-id",
+      "name": "jsonrpc.validation.response.allow-string-id",
       "type": "java.lang.Boolean",
       "defaultValue": true,
       "description": "Allow string ids in incoming responses."
     },
     {
-      "name": "jsonrpc.validation.response.allow-numeric-response-id",
+      "name": "jsonrpc.validation.response.allow-numeric-id",
       "type": "java.lang.Boolean",
       "defaultValue": true,
       "description": "Allow numeric ids in incoming responses."
     },
     {
-      "name": "jsonrpc.validation.response.allow-fractional-response-id",
+      "name": "jsonrpc.validation.response.allow-fractional-id",
       "type": "java.lang.Boolean",
       "defaultValue": true,
       "description": "Allow fractional numeric ids in incoming responses."
@@ -144,10 +192,32 @@
       "description": "Require error.message to be a string when validated."
     },
     {
-      "name": "jsonrpc.validation.response.allow-request-fields-in-response",
+      "name": "jsonrpc.validation.response.reject-request-fields",
       "type": "java.lang.Boolean",
-      "defaultValue": true,
-      "description": "Allow request-only fields (method/params) in incoming responses."
+      "defaultValue": false,
+      "description": "Reject response objects containing request-only fields (method/params)."
+    },
+    {
+      "name": "jsonrpc.validation.response.reject-duplicate-members",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Reject duplicate members when parsing raw JSON response payloads."
+    },
+    {
+      "name": "jsonrpc.validation.response.error-code.policy",
+      "type": "com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy",
+      "defaultValue": "ANY_INTEGER",
+      "description": "Accepted integer range policy for incoming response error.code values."
+    },
+    {
+      "name": "jsonrpc.validation.response.error-code.range.min",
+      "type": "java.lang.Integer",
+      "description": "Inclusive minimum value for CUSTOM_RANGE error-code policy."
+    },
+    {
+      "name": "jsonrpc.validation.response.error-code.range.max",
+      "type": "java.lang.Integer",
+      "description": "Inclusive maximum value for CUSTOM_RANGE error-code policy."
     },
     {
       "name": "jsonrpc.method-allowlist",
@@ -191,6 +261,23 @@
         },
         {
           "value": "INVALID_REQUEST"
+        }
+      ]
+    },
+    {
+      "name": "jsonrpc.validation.response.error-code.policy",
+      "values": [
+        {
+          "value": "ANY_INTEGER"
+        },
+        {
+          "value": "STANDARD_ONLY"
+        },
+        {
+          "value": "STANDARD_OR_SERVER_ERROR_RANGE"
+        },
+        {
+          "value": "CUSTOM_RANGE"
         }
       ]
     },

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAnnotatedMethodRegistrarTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAnnotatedMethodRegistrarTest.java
@@ -15,13 +15,13 @@ import com.limehee.jsonrpc.core.DirectJsonRpcNotificationExecutor;
 import com.limehee.jsonrpc.core.InMemoryJsonRpcMethodRegistry;
 import com.limehee.jsonrpc.core.JacksonJsonRpcParameterBinder;
 import com.limehee.jsonrpc.core.JacksonJsonRpcResultWriter;
+import com.limehee.jsonrpc.core.JsonRpcDispatcher;
 import com.limehee.jsonrpc.core.JsonRpcErrorCode;
 import com.limehee.jsonrpc.core.JsonRpcExceptionResolver;
 import com.limehee.jsonrpc.core.JsonRpcMethod;
 import com.limehee.jsonrpc.core.JsonRpcRequest;
 import com.limehee.jsonrpc.core.JsonRpcResponse;
 import com.limehee.jsonrpc.core.JsonRpcTypedMethodHandlerFactory;
-import com.limehee.jsonrpc.core.JsonRpcDispatcher;
 import com.limehee.jsonrpc.spring.boot.autoconfigure.support.JsonRpcAnnotatedMethodRegistrar;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -44,7 +44,8 @@ class JsonRpcAnnotatedMethodRegistrarTest {
         JsonRpcDispatcher dispatcher = new JsonRpcDispatcher();
         JsonRpcAnnotatedMethodRegistrar registrar = registrar(beanFactory, dispatcher);
 
-        IllegalStateException exception = assertThrows(IllegalStateException.class, registrar::afterSingletonsInstantiated);
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            registrar::afterSingletonsInstantiated);
         assertTrue(exception.getMessage().contains("failingBean"));
     }
 
@@ -88,7 +89,8 @@ class JsonRpcAnnotatedMethodRegistrarTest {
         assertEquals("checked failure", captured.get().getCause().getMessage());
     }
 
-    private JsonRpcAnnotatedMethodRegistrar registrar(DefaultListableBeanFactory beanFactory, JsonRpcDispatcher dispatcher) {
+    private JsonRpcAnnotatedMethodRegistrar registrar(DefaultListableBeanFactory beanFactory,
+        JsonRpcDispatcher dispatcher) {
         JacksonJsonRpcParameterBinder parameterBinder = new JacksonJsonRpcParameterBinder(OBJECT_MAPPER);
         JacksonJsonRpcResultWriter resultWriter = new JacksonJsonRpcResultWriter(OBJECT_MAPPER);
         JsonRpcTypedMethodHandlerFactory typedFactory = new DefaultJsonRpcTypedMethodHandlerFactory(

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAnnotatedMethodRegistrarTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAnnotatedMethodRegistrarTest.java
@@ -1,0 +1,126 @@
+package com.limehee.jsonrpc.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.limehee.jsonrpc.core.DefaultJsonRpcExceptionResolver;
+import com.limehee.jsonrpc.core.DefaultJsonRpcMethodInvoker;
+import com.limehee.jsonrpc.core.DefaultJsonRpcRequestParser;
+import com.limehee.jsonrpc.core.DefaultJsonRpcRequestValidator;
+import com.limehee.jsonrpc.core.DefaultJsonRpcResponseComposer;
+import com.limehee.jsonrpc.core.DefaultJsonRpcTypedMethodHandlerFactory;
+import com.limehee.jsonrpc.core.DirectJsonRpcNotificationExecutor;
+import com.limehee.jsonrpc.core.InMemoryJsonRpcMethodRegistry;
+import com.limehee.jsonrpc.core.JacksonJsonRpcParameterBinder;
+import com.limehee.jsonrpc.core.JacksonJsonRpcResultWriter;
+import com.limehee.jsonrpc.core.JsonRpcErrorCode;
+import com.limehee.jsonrpc.core.JsonRpcExceptionResolver;
+import com.limehee.jsonrpc.core.JsonRpcMethod;
+import com.limehee.jsonrpc.core.JsonRpcRequest;
+import com.limehee.jsonrpc.core.JsonRpcResponse;
+import com.limehee.jsonrpc.core.JsonRpcTypedMethodHandlerFactory;
+import com.limehee.jsonrpc.core.JsonRpcDispatcher;
+import com.limehee.jsonrpc.spring.boot.autoconfigure.support.JsonRpcAnnotatedMethodRegistrar;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.IntNode;
+
+class JsonRpcAnnotatedMethodRegistrarTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
+
+    @Test
+    void failsFastWhenAnnotatedBeanCannotBeCreated() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("failingBean", new RootBeanDefinition(FailingAnnotatedBean.class));
+
+        JsonRpcDispatcher dispatcher = new JsonRpcDispatcher();
+        JsonRpcAnnotatedMethodRegistrar registrar = registrar(beanFactory, dispatcher);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, registrar::afterSingletonsInstantiated);
+        assertTrue(exception.getMessage().contains("failingBean"));
+    }
+
+    @Test
+    void wrapsCheckedTargetExceptionFromAnnotatedMethodInvocation() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("checkedBean", new RootBeanDefinition(CheckedExceptionAnnotatedBean.class));
+
+        AtomicReference<Throwable> captured = new AtomicReference<>();
+        JsonRpcExceptionResolver exceptionResolver = throwable -> {
+            captured.set(throwable);
+            return new DefaultJsonRpcExceptionResolver(false).resolve(throwable);
+        };
+
+        JsonRpcDispatcher dispatcher = new JsonRpcDispatcher(
+            new InMemoryJsonRpcMethodRegistry(),
+            new DefaultJsonRpcRequestParser(),
+            new DefaultJsonRpcRequestValidator(),
+            new DefaultJsonRpcMethodInvoker(),
+            exceptionResolver,
+            new DefaultJsonRpcResponseComposer(),
+            100,
+            List.of(),
+            new DirectJsonRpcNotificationExecutor()
+        );
+
+        JsonRpcAnnotatedMethodRegistrar registrar = registrar(beanFactory, dispatcher);
+        registrar.afterSingletonsInstantiated();
+
+        JsonRpcResponse response = dispatcher.dispatch(
+            new JsonRpcRequest("2.0", IntNode.valueOf(1), "checked.fail", null, true)
+        );
+
+        assertNotNull(response);
+        assertNotNull(response.error());
+        assertEquals(JsonRpcErrorCode.INTERNAL_ERROR, response.error().code());
+        assertNotNull(captured.get());
+        assertTrue(captured.get() instanceof RuntimeException);
+        assertNotNull(captured.get().getCause());
+        assertEquals(Exception.class, captured.get().getCause().getClass());
+        assertEquals("checked failure", captured.get().getCause().getMessage());
+    }
+
+    private JsonRpcAnnotatedMethodRegistrar registrar(DefaultListableBeanFactory beanFactory, JsonRpcDispatcher dispatcher) {
+        JacksonJsonRpcParameterBinder parameterBinder = new JacksonJsonRpcParameterBinder(OBJECT_MAPPER);
+        JacksonJsonRpcResultWriter resultWriter = new JacksonJsonRpcResultWriter(OBJECT_MAPPER);
+        JsonRpcTypedMethodHandlerFactory typedFactory = new DefaultJsonRpcTypedMethodHandlerFactory(
+            parameterBinder,
+            resultWriter
+        );
+        return new JsonRpcAnnotatedMethodRegistrar(
+            beanFactory,
+            dispatcher,
+            typedFactory,
+            parameterBinder,
+            resultWriter
+        );
+    }
+
+    static class FailingAnnotatedBean {
+
+        FailingAnnotatedBean() {
+            throw new IllegalStateException("creation failed");
+        }
+
+        @JsonRpcMethod("never")
+        public String never() {
+            return "never";
+        }
+    }
+
+    static class CheckedExceptionAnnotatedBean {
+
+        @JsonRpcMethod("checked.fail")
+        public String fail() throws Exception {
+            throw new Exception("checked failure");
+        }
+    }
+}

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
@@ -25,10 +25,13 @@ import com.limehee.jsonrpc.core.JsonRpcResponseValidator;
 import com.limehee.jsonrpc.core.JsonRpcTypedMethodHandlerFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -664,6 +667,81 @@ class JsonRpcAutoConfigurationTest {
     }
 
     @Test
+    void appliesAllRequestBooleanOptionsWhenSetTrue() {
+        contextRunner
+            .withPropertyValues(
+                "jsonrpc.validation.request.require-json-rpc-version-20=true",
+                "jsonrpc.validation.request.require-id-member=true",
+                "jsonrpc.validation.request.allow-null-id=true",
+                "jsonrpc.validation.request.allow-string-id=true",
+                "jsonrpc.validation.request.allow-numeric-id=true",
+                "jsonrpc.validation.request.allow-fractional-id=true",
+                "jsonrpc.validation.request.reject-response-fields=true",
+                "jsonrpc.validation.request.reject-duplicate-members=true"
+            )
+            .run(context -> {
+                JsonRpcRequestValidationOptions options = context.getBean(JsonRpcRequestValidationOptions.class);
+
+                assertTrue(options.requireJsonRpcVersion20());
+                assertTrue(options.requireIdMember());
+                assertTrue(options.allowNullId());
+                assertTrue(options.allowStringId());
+                assertTrue(options.allowNumericId());
+                assertTrue(options.allowFractionalId());
+                assertTrue(options.rejectResponseFields());
+                assertTrue(options.rejectDuplicateMembers());
+            });
+    }
+
+    @Test
+    void appliesAllRequestBooleanOptionsWhenSetFalse() {
+        contextRunner
+            .withPropertyValues(
+                "jsonrpc.validation.request.require-json-rpc-version-20=false",
+                "jsonrpc.validation.request.require-id-member=false",
+                "jsonrpc.validation.request.allow-null-id=false",
+                "jsonrpc.validation.request.allow-string-id=false",
+                "jsonrpc.validation.request.allow-numeric-id=false",
+                "jsonrpc.validation.request.allow-fractional-id=false",
+                "jsonrpc.validation.request.reject-response-fields=false",
+                "jsonrpc.validation.request.reject-duplicate-members=false"
+            )
+            .run(context -> {
+                JsonRpcRequestValidationOptions options = context.getBean(JsonRpcRequestValidationOptions.class);
+
+                assertFalse(options.requireJsonRpcVersion20());
+                assertFalse(options.requireIdMember());
+                assertFalse(options.allowNullId());
+                assertFalse(options.allowStringId());
+                assertFalse(options.allowNumericId());
+                assertFalse(options.allowFractionalId());
+                assertFalse(options.rejectResponseFields());
+                assertFalse(options.rejectDuplicateMembers());
+            });
+    }
+
+    @Test
+    void bindsEachRequestBooleanOptionIndependentlyForTrueAndFalse() {
+        JsonRpcRequestValidationOptions defaults = JsonRpcRequestValidationOptions.defaults();
+        Map<String, Function<JsonRpcRequestValidationOptions, Boolean>> flags = new LinkedHashMap<>();
+        flags.put("jsonrpc.validation.request.require-json-rpc-version-20",
+            JsonRpcRequestValidationOptions::requireJsonRpcVersion20);
+        flags.put("jsonrpc.validation.request.require-id-member", JsonRpcRequestValidationOptions::requireIdMember);
+        flags.put("jsonrpc.validation.request.allow-null-id", JsonRpcRequestValidationOptions::allowNullId);
+        flags.put("jsonrpc.validation.request.allow-string-id", JsonRpcRequestValidationOptions::allowStringId);
+        flags.put("jsonrpc.validation.request.allow-numeric-id", JsonRpcRequestValidationOptions::allowNumericId);
+        flags.put("jsonrpc.validation.request.allow-fractional-id", JsonRpcRequestValidationOptions::allowFractionalId);
+        flags.put("jsonrpc.validation.request.reject-response-fields", JsonRpcRequestValidationOptions::rejectResponseFields);
+        flags.put("jsonrpc.validation.request.reject-duplicate-members",
+            JsonRpcRequestValidationOptions::rejectDuplicateMembers);
+
+        for (Map.Entry<String, Function<JsonRpcRequestValidationOptions, Boolean>> target : flags.entrySet()) {
+            assertRequestBooleanFlagBinding(flags, defaults, target.getKey(), true);
+            assertRequestBooleanFlagBinding(flags, defaults, target.getKey(), false);
+        }
+    }
+
+    @Test
     void enforcesRequireIdMemberForNotificationLikeRequestWhenConfigured() {
         contextRunner
             .withPropertyValues("jsonrpc.validation.request.require-id-member=true")
@@ -753,6 +831,105 @@ class JsonRpcAutoConfigurationTest {
                 assertEquals(-45000, options.errorCodeRangeMin());
                 assertEquals(-44000, options.errorCodeRangeMax());
             });
+    }
+
+    @Test
+    void appliesAllResponseBooleanOptionsWhenSetTrue() {
+        contextRunner
+            .withPropertyValues(
+                "jsonrpc.validation.response.require-json-rpc-version-20=true",
+                "jsonrpc.validation.response.require-id-member=true",
+                "jsonrpc.validation.response.allow-null-id=true",
+                "jsonrpc.validation.response.allow-string-id=true",
+                "jsonrpc.validation.response.allow-numeric-id=true",
+                "jsonrpc.validation.response.allow-fractional-id=true",
+                "jsonrpc.validation.response.require-exclusive-result-or-error=true",
+                "jsonrpc.validation.response.require-error-object-when-present=true",
+                "jsonrpc.validation.response.require-integer-error-code=true",
+                "jsonrpc.validation.response.require-string-error-message=true",
+                "jsonrpc.validation.response.reject-request-fields=true",
+                "jsonrpc.validation.response.reject-duplicate-members=true"
+            )
+            .run(context -> {
+                JsonRpcResponseValidationOptions options = context.getBean(JsonRpcResponseValidationOptions.class);
+
+                assertTrue(options.requireJsonRpcVersion20());
+                assertTrue(options.requireIdMember());
+                assertTrue(options.allowNullId());
+                assertTrue(options.allowStringId());
+                assertTrue(options.allowNumericId());
+                assertTrue(options.allowFractionalId());
+                assertTrue(options.requireExclusiveResultOrError());
+                assertTrue(options.requireErrorObjectWhenPresent());
+                assertTrue(options.requireIntegerErrorCode());
+                assertTrue(options.requireStringErrorMessage());
+                assertTrue(options.rejectRequestFields());
+                assertTrue(options.rejectDuplicateMembers());
+            });
+    }
+
+    @Test
+    void appliesAllResponseBooleanOptionsWhenSetFalse() {
+        contextRunner
+            .withPropertyValues(
+                "jsonrpc.validation.response.require-json-rpc-version-20=false",
+                "jsonrpc.validation.response.require-id-member=false",
+                "jsonrpc.validation.response.allow-null-id=false",
+                "jsonrpc.validation.response.allow-string-id=false",
+                "jsonrpc.validation.response.allow-numeric-id=false",
+                "jsonrpc.validation.response.allow-fractional-id=false",
+                "jsonrpc.validation.response.require-exclusive-result-or-error=false",
+                "jsonrpc.validation.response.require-error-object-when-present=false",
+                "jsonrpc.validation.response.require-integer-error-code=false",
+                "jsonrpc.validation.response.require-string-error-message=false",
+                "jsonrpc.validation.response.reject-request-fields=false",
+                "jsonrpc.validation.response.reject-duplicate-members=false"
+            )
+            .run(context -> {
+                JsonRpcResponseValidationOptions options = context.getBean(JsonRpcResponseValidationOptions.class);
+
+                assertFalse(options.requireJsonRpcVersion20());
+                assertFalse(options.requireIdMember());
+                assertFalse(options.allowNullId());
+                assertFalse(options.allowStringId());
+                assertFalse(options.allowNumericId());
+                assertFalse(options.allowFractionalId());
+                assertFalse(options.requireExclusiveResultOrError());
+                assertFalse(options.requireErrorObjectWhenPresent());
+                assertFalse(options.requireIntegerErrorCode());
+                assertFalse(options.requireStringErrorMessage());
+                assertFalse(options.rejectRequestFields());
+                assertFalse(options.rejectDuplicateMembers());
+            });
+    }
+
+    @Test
+    void bindsEachResponseBooleanOptionIndependentlyForTrueAndFalse() {
+        JsonRpcResponseValidationOptions defaults = JsonRpcResponseValidationOptions.defaults();
+        Map<String, Function<JsonRpcResponseValidationOptions, Boolean>> flags = new LinkedHashMap<>();
+        flags.put("jsonrpc.validation.response.require-json-rpc-version-20",
+            JsonRpcResponseValidationOptions::requireJsonRpcVersion20);
+        flags.put("jsonrpc.validation.response.require-id-member", JsonRpcResponseValidationOptions::requireIdMember);
+        flags.put("jsonrpc.validation.response.allow-null-id", JsonRpcResponseValidationOptions::allowNullId);
+        flags.put("jsonrpc.validation.response.allow-string-id", JsonRpcResponseValidationOptions::allowStringId);
+        flags.put("jsonrpc.validation.response.allow-numeric-id", JsonRpcResponseValidationOptions::allowNumericId);
+        flags.put("jsonrpc.validation.response.allow-fractional-id", JsonRpcResponseValidationOptions::allowFractionalId);
+        flags.put("jsonrpc.validation.response.require-exclusive-result-or-error",
+            JsonRpcResponseValidationOptions::requireExclusiveResultOrError);
+        flags.put("jsonrpc.validation.response.require-error-object-when-present",
+            JsonRpcResponseValidationOptions::requireErrorObjectWhenPresent);
+        flags.put("jsonrpc.validation.response.require-integer-error-code",
+            JsonRpcResponseValidationOptions::requireIntegerErrorCode);
+        flags.put("jsonrpc.validation.response.require-string-error-message",
+            JsonRpcResponseValidationOptions::requireStringErrorMessage);
+        flags.put("jsonrpc.validation.response.reject-request-fields", JsonRpcResponseValidationOptions::rejectRequestFields);
+        flags.put("jsonrpc.validation.response.reject-duplicate-members",
+            JsonRpcResponseValidationOptions::rejectDuplicateMembers);
+
+        for (Map.Entry<String, Function<JsonRpcResponseValidationOptions, Boolean>> target : flags.entrySet()) {
+            assertResponseBooleanFlagBinding(flags, defaults, target.getKey(), true);
+            assertResponseBooleanFlagBinding(flags, defaults, target.getKey(), false);
+        }
     }
 
     @Test
@@ -994,6 +1171,44 @@ class JsonRpcAutoConfigurationTest {
             )
             .withUserConfiguration(NotificationExecutorConfig.class)
             .run(context -> assertNotNull(context.getStartupFailure()));
+    }
+
+    private void assertRequestBooleanFlagBinding(
+        Map<String, Function<JsonRpcRequestValidationOptions, Boolean>> flags,
+        JsonRpcRequestValidationOptions defaults,
+        String targetProperty,
+        boolean targetValue
+    ) {
+        contextRunner
+            .withPropertyValues(targetProperty + "=" + targetValue)
+            .run(context -> {
+                JsonRpcRequestValidationOptions options = context.getBean(JsonRpcRequestValidationOptions.class);
+                for (Map.Entry<String, Function<JsonRpcRequestValidationOptions, Boolean>> entry : flags.entrySet()) {
+                    boolean expected = entry.getKey().equals(targetProperty)
+                        ? targetValue
+                        : entry.getValue().apply(defaults);
+                    assertEquals(expected, entry.getValue().apply(options));
+                }
+            });
+    }
+
+    private void assertResponseBooleanFlagBinding(
+        Map<String, Function<JsonRpcResponseValidationOptions, Boolean>> flags,
+        JsonRpcResponseValidationOptions defaults,
+        String targetProperty,
+        boolean targetValue
+    ) {
+        contextRunner
+            .withPropertyValues(targetProperty + "=" + targetValue)
+            .run(context -> {
+                JsonRpcResponseValidationOptions options = context.getBean(JsonRpcResponseValidationOptions.class);
+                for (Map.Entry<String, Function<JsonRpcResponseValidationOptions, Boolean>> entry : flags.entrySet()) {
+                    boolean expected = entry.getKey().equals(targetProperty)
+                        ? targetValue
+                        : entry.getValue().apply(defaults);
+                    assertEquals(expected, entry.getValue().apply(options));
+                }
+            });
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
@@ -13,7 +13,9 @@ import com.limehee.jsonrpc.core.JsonRpcMethod;
 import com.limehee.jsonrpc.core.JsonRpcMethodRegistration;
 import com.limehee.jsonrpc.core.JsonRpcParam;
 import com.limehee.jsonrpc.core.JsonRpcRequest;
+import com.limehee.jsonrpc.core.JsonRpcRequestValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponse;
+import com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidator;
 import com.limehee.jsonrpc.core.JsonRpcTypedMethodHandlerFactory;
@@ -621,6 +623,40 @@ class JsonRpcAutoConfigurationTest {
     }
 
     @Test
+    void bindsDefaultRequestValidationOptions() {
+        contextRunner.run(context -> {
+            JsonRpcRequestValidationOptions options = context.getBean(JsonRpcRequestValidationOptions.class);
+            JsonRpcRequestValidationOptions coreDefaults = JsonRpcRequestValidationOptions.defaults();
+
+            assertEquals(coreDefaults.requireJsonRpcVersion20(), options.requireJsonRpcVersion20());
+            assertEquals(coreDefaults.requireIdMember(), options.requireIdMember());
+            assertEquals(coreDefaults.allowNullId(), options.allowNullId());
+            assertEquals(coreDefaults.allowStringId(), options.allowStringId());
+            assertEquals(coreDefaults.allowNumericId(), options.allowNumericId());
+            assertEquals(coreDefaults.allowFractionalId(), options.allowFractionalId());
+            assertEquals(coreDefaults.rejectResponseFields(), options.rejectResponseFields());
+            assertEquals(coreDefaults.paramsTypeViolationCodePolicy(), options.paramsTypeViolationCodePolicy());
+        });
+    }
+
+    @Test
+    void appliesConfiguredRequestValidationOptions() {
+        contextRunner
+            .withPropertyValues(
+                "jsonrpc.validation.request.require-id-member=true",
+                "jsonrpc.validation.request.allow-fractional-id=false",
+                "jsonrpc.validation.request.reject-response-fields=true"
+            )
+            .run(context -> {
+                JsonRpcRequestValidationOptions options = context.getBean(JsonRpcRequestValidationOptions.class);
+
+                assertTrue(options.requireIdMember());
+                assertFalse(options.allowFractionalId());
+                assertTrue(options.rejectResponseFields());
+            });
+    }
+
+    @Test
     void bindsDefaultResponseValidationOptions() {
         contextRunner.run(context -> {
             JsonRpcResponseValidationOptions options = context.getBean(JsonRpcResponseValidationOptions.class);
@@ -628,16 +664,19 @@ class JsonRpcAutoConfigurationTest {
             JsonRpcResponseValidationOptions coreDefaults = JsonRpcResponseValidationOptions.defaults();
 
             assertEquals(coreDefaults.requireJsonRpcVersion20(), options.requireJsonRpcVersion20());
-            assertEquals(coreDefaults.requireResponseIdMember(), options.requireResponseIdMember());
-            assertEquals(coreDefaults.allowNullResponseId(), options.allowNullResponseId());
-            assertEquals(coreDefaults.allowStringResponseId(), options.allowStringResponseId());
-            assertEquals(coreDefaults.allowNumericResponseId(), options.allowNumericResponseId());
-            assertEquals(coreDefaults.allowFractionalResponseId(), options.allowFractionalResponseId());
+            assertEquals(coreDefaults.requireIdMember(), options.requireIdMember());
+            assertEquals(coreDefaults.allowNullId(), options.allowNullId());
+            assertEquals(coreDefaults.allowStringId(), options.allowStringId());
+            assertEquals(coreDefaults.allowNumericId(), options.allowNumericId());
+            assertEquals(coreDefaults.allowFractionalId(), options.allowFractionalId());
             assertEquals(coreDefaults.requireExclusiveResultOrError(), options.requireExclusiveResultOrError());
             assertEquals(coreDefaults.requireErrorObjectWhenPresent(), options.requireErrorObjectWhenPresent());
             assertEquals(coreDefaults.requireIntegerErrorCode(), options.requireIntegerErrorCode());
             assertEquals(coreDefaults.requireStringErrorMessage(), options.requireStringErrorMessage());
-            assertEquals(coreDefaults.allowRequestFieldsInResponse(), options.allowRequestFieldsInResponse());
+            assertEquals(coreDefaults.rejectRequestFields(), options.rejectRequestFields());
+            assertEquals(coreDefaults.errorCodePolicy(), options.errorCodePolicy());
+            assertEquals(coreDefaults.errorCodeRangeMin(), options.errorCodeRangeMin());
+            assertEquals(coreDefaults.errorCodeRangeMax(), options.errorCodeRangeMax());
             assertNotNull(responseValidator);
         });
     }
@@ -646,17 +685,51 @@ class JsonRpcAutoConfigurationTest {
     void appliesConfiguredResponseValidationOptions() {
         contextRunner
             .withPropertyValues(
-                "jsonrpc.validation.response.require-response-id-member=false",
-                "jsonrpc.validation.response.allow-fractional-response-id=false",
-                "jsonrpc.validation.response.allow-request-fields-in-response=false"
+                "jsonrpc.validation.response.require-id-member=false",
+                "jsonrpc.validation.response.allow-fractional-id=false",
+                "jsonrpc.validation.response.reject-request-fields=true",
+                "jsonrpc.validation.response.error-code.policy=CUSTOM_RANGE",
+                "jsonrpc.validation.response.error-code.range.min=-45000",
+                "jsonrpc.validation.response.error-code.range.max=-44000"
             )
             .run(context -> {
                 JsonRpcResponseValidationOptions options = context.getBean(JsonRpcResponseValidationOptions.class);
 
-                assertFalse(options.requireResponseIdMember());
-                assertFalse(options.allowFractionalResponseId());
-                assertFalse(options.allowRequestFieldsInResponse());
+                assertFalse(options.requireIdMember());
+                assertFalse(options.allowFractionalId());
+                assertTrue(options.rejectRequestFields());
+                assertTrue(options.errorCodePolicy() == JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE);
+                assertEquals(-45000, options.errorCodeRangeMin());
+                assertEquals(-44000, options.errorCodeRangeMax());
             });
+    }
+
+    @Test
+    void rejectsResponseErrorCodePolicyWithoutIntegerCodeValidation() {
+        contextRunner
+            .withPropertyValues(
+                "jsonrpc.validation.response.require-integer-error-code=false",
+                "jsonrpc.validation.response.error-code.policy=STANDARD_ONLY"
+            )
+            .run(context -> assertNotNull(context.getStartupFailure()));
+    }
+
+    @Test
+    void rejectsCustomRangePolicyWhenBoundsAreMissing() {
+        contextRunner
+            .withPropertyValues("jsonrpc.validation.response.error-code.policy=CUSTOM_RANGE")
+            .run(context -> assertNotNull(context.getStartupFailure()));
+    }
+
+    @Test
+    void rejectsCustomRangePolicyWhenBoundsAreInverted() {
+        contextRunner
+            .withPropertyValues(
+                "jsonrpc.validation.response.error-code.policy=CUSTOM_RANGE",
+                "jsonrpc.validation.response.error-code.range.min=-32000",
+                "jsonrpc.validation.response.error-code.range.max=-32100"
+            )
+            .run(context -> assertNotNull(context.getStartupFailure()));
     }
 
     @Test

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
@@ -4,9 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.limehee.jsonrpc.core.JsonRpcDispatcher;
+import com.limehee.jsonrpc.core.DefaultJsonRpcResponseParser;
 import com.limehee.jsonrpc.core.JsonRpcException;
 import com.limehee.jsonrpc.core.JsonRpcInterceptor;
 import com.limehee.jsonrpc.core.JsonRpcMethod;
@@ -15,6 +17,7 @@ import com.limehee.jsonrpc.core.JsonRpcParam;
 import com.limehee.jsonrpc.core.JsonRpcRequest;
 import com.limehee.jsonrpc.core.JsonRpcRequestValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponse;
+import com.limehee.jsonrpc.core.JsonRpcResponseParser;
 import com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidator;
@@ -730,6 +733,23 @@ class JsonRpcAutoConfigurationTest {
                 "jsonrpc.validation.response.error-code.range.max=-32100"
             )
             .run(context -> assertNotNull(context.getStartupFailure()));
+    }
+
+    @Test
+    void appliesResponseDuplicateMemberRejectionToResponseParserBean() {
+        contextRunner
+            .withPropertyValues("jsonrpc.validation.response.reject-duplicate-members=true")
+            .run(context -> {
+                JsonRpcResponseParser parser = context.getBean(JsonRpcResponseParser.class);
+                assertTrue(parser instanceof DefaultJsonRpcResponseParser);
+
+                DefaultJsonRpcResponseParser defaultParser = (DefaultJsonRpcResponseParser) parser;
+
+                assertNotNull(assertThrows(
+                    JsonRpcException.class,
+                    () -> defaultParser.parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}")
+                ));
+            });
     }
 
     @Test

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.limehee.jsonrpc.core.JsonRpcDispatcher;
 import com.limehee.jsonrpc.core.DefaultJsonRpcResponseParser;
+import com.limehee.jsonrpc.core.JsonRpcDispatcher;
 import com.limehee.jsonrpc.core.JsonRpcException;
 import com.limehee.jsonrpc.core.JsonRpcIncomingResponse;
 import com.limehee.jsonrpc.core.JsonRpcInterceptor;
@@ -18,8 +18,8 @@ import com.limehee.jsonrpc.core.JsonRpcParam;
 import com.limehee.jsonrpc.core.JsonRpcRequest;
 import com.limehee.jsonrpc.core.JsonRpcRequestValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponse;
-import com.limehee.jsonrpc.core.JsonRpcResponseParser;
 import com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy;
+import com.limehee.jsonrpc.core.JsonRpcResponseParser;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidator;
 import com.limehee.jsonrpc.core.JsonRpcTypedMethodHandlerFactory;
@@ -731,7 +731,8 @@ class JsonRpcAutoConfigurationTest {
         flags.put("jsonrpc.validation.request.allow-string-id", JsonRpcRequestValidationOptions::allowStringId);
         flags.put("jsonrpc.validation.request.allow-numeric-id", JsonRpcRequestValidationOptions::allowNumericId);
         flags.put("jsonrpc.validation.request.allow-fractional-id", JsonRpcRequestValidationOptions::allowFractionalId);
-        flags.put("jsonrpc.validation.request.reject-response-fields", JsonRpcRequestValidationOptions::rejectResponseFields);
+        flags.put("jsonrpc.validation.request.reject-response-fields",
+            JsonRpcRequestValidationOptions::rejectResponseFields);
         flags.put("jsonrpc.validation.request.reject-duplicate-members",
             JsonRpcRequestValidationOptions::rejectDuplicateMembers);
 
@@ -913,7 +914,8 @@ class JsonRpcAutoConfigurationTest {
         flags.put("jsonrpc.validation.response.allow-null-id", JsonRpcResponseValidationOptions::allowNullId);
         flags.put("jsonrpc.validation.response.allow-string-id", JsonRpcResponseValidationOptions::allowStringId);
         flags.put("jsonrpc.validation.response.allow-numeric-id", JsonRpcResponseValidationOptions::allowNumericId);
-        flags.put("jsonrpc.validation.response.allow-fractional-id", JsonRpcResponseValidationOptions::allowFractionalId);
+        flags.put("jsonrpc.validation.response.allow-fractional-id",
+            JsonRpcResponseValidationOptions::allowFractionalId);
         flags.put("jsonrpc.validation.response.require-exclusive-result-or-error",
             JsonRpcResponseValidationOptions::requireExclusiveResultOrError);
         flags.put("jsonrpc.validation.response.require-error-object-when-present",
@@ -922,7 +924,8 @@ class JsonRpcAutoConfigurationTest {
             JsonRpcResponseValidationOptions::requireIntegerErrorCode);
         flags.put("jsonrpc.validation.response.require-string-error-message",
             JsonRpcResponseValidationOptions::requireStringErrorMessage);
-        flags.put("jsonrpc.validation.response.reject-request-fields", JsonRpcResponseValidationOptions::rejectRequestFields);
+        flags.put("jsonrpc.validation.response.reject-request-fields",
+            JsonRpcResponseValidationOptions::rejectRequestFields);
         flags.put("jsonrpc.validation.response.reject-duplicate-members",
             JsonRpcResponseValidationOptions::rejectDuplicateMembers);
 

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
@@ -638,6 +638,7 @@ class JsonRpcAutoConfigurationTest {
             assertEquals(coreDefaults.allowNumericId(), options.allowNumericId());
             assertEquals(coreDefaults.allowFractionalId(), options.allowFractionalId());
             assertEquals(coreDefaults.rejectResponseFields(), options.rejectResponseFields());
+            assertEquals(coreDefaults.rejectDuplicateMembers(), options.rejectDuplicateMembers());
             assertEquals(coreDefaults.paramsTypeViolationCodePolicy(), options.paramsTypeViolationCodePolicy());
         });
     }
@@ -648,7 +649,8 @@ class JsonRpcAutoConfigurationTest {
             .withPropertyValues(
                 "jsonrpc.validation.request.require-id-member=true",
                 "jsonrpc.validation.request.allow-fractional-id=false",
-                "jsonrpc.validation.request.reject-response-fields=true"
+                "jsonrpc.validation.request.reject-response-fields=true",
+                "jsonrpc.validation.request.reject-duplicate-members=true"
             )
             .run(context -> {
                 JsonRpcRequestValidationOptions options = context.getBean(JsonRpcRequestValidationOptions.class);
@@ -656,6 +658,7 @@ class JsonRpcAutoConfigurationTest {
                 assertTrue(options.requireIdMember());
                 assertFalse(options.allowFractionalId());
                 assertTrue(options.rejectResponseFields());
+                assertTrue(options.rejectDuplicateMembers());
             });
     }
 
@@ -745,10 +748,23 @@ class JsonRpcAutoConfigurationTest {
 
                 DefaultJsonRpcResponseParser defaultParser = (DefaultJsonRpcResponseParser) parser;
 
-                assertNotNull(assertThrows(
+                assertThrows(
                     JsonRpcException.class,
                     () -> defaultParser.parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}")
-                ));
+                );
+            });
+    }
+
+    @Test
+    void keepsResponseDuplicateMemberAcceptanceWhenPolicyIsDisabled() {
+        contextRunner
+            .withPropertyValues("jsonrpc.validation.response.reject-duplicate-members=false")
+            .run(context -> {
+                JsonRpcResponseParser parser = context.getBean(JsonRpcResponseParser.class);
+                assertTrue(parser instanceof DefaultJsonRpcResponseParser);
+
+                DefaultJsonRpcResponseParser defaultParser = (DefaultJsonRpcResponseParser) parser;
+                assertNotNull(defaultParser.parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}"));
             });
     }
 

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
@@ -1013,6 +1013,47 @@ class JsonRpcAutoConfigurationTest {
     }
 
     @Test
+    void customResponseValidationOptionsCanEnableDuplicateMemberRejectionEvenWhenPropertyIsDisabled() {
+        contextRunner
+            .withPropertyValues("jsonrpc.validation.response.reject-duplicate-members=false")
+            .withBean(
+                JsonRpcResponseValidationOptions.class,
+                () -> JsonRpcResponseValidationOptions.builder()
+                    .rejectDuplicateMembers(true)
+                    .build()
+            )
+            .run(context -> {
+                JsonRpcResponseParser parser = context.getBean(JsonRpcResponseParser.class);
+                assertTrue(parser instanceof DefaultJsonRpcResponseParser);
+
+                DefaultJsonRpcResponseParser defaultParser = (DefaultJsonRpcResponseParser) parser;
+                assertThrows(
+                    JsonRpcException.class,
+                    () -> defaultParser.parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}")
+                );
+            });
+    }
+
+    @Test
+    void customResponseValidationOptionsCanDisableDuplicateMemberRejectionEvenWhenPropertyIsEnabled() {
+        contextRunner
+            .withPropertyValues("jsonrpc.validation.response.reject-duplicate-members=true")
+            .withBean(
+                JsonRpcResponseValidationOptions.class,
+                () -> JsonRpcResponseValidationOptions.builder()
+                    .rejectDuplicateMembers(false)
+                    .build()
+            )
+            .run(context -> {
+                JsonRpcResponseParser parser = context.getBean(JsonRpcResponseParser.class);
+                assertTrue(parser instanceof DefaultJsonRpcResponseParser);
+
+                DefaultJsonRpcResponseParser defaultParser = (DefaultJsonRpcResponseParser) parser;
+                assertNotNull(defaultParser.parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"id\":2,\"result\":1}"));
+            });
+    }
+
+    @Test
     void rejectsMaxBatchSizeLessThanOne() {
         contextRunner
             .withPropertyValues("jsonrpc.max-batch-size=0")

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcAutoConfigurationTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.limehee.jsonrpc.core.JsonRpcDispatcher;
 import com.limehee.jsonrpc.core.DefaultJsonRpcResponseParser;
 import com.limehee.jsonrpc.core.JsonRpcException;
+import com.limehee.jsonrpc.core.JsonRpcIncomingResponse;
 import com.limehee.jsonrpc.core.JsonRpcInterceptor;
 import com.limehee.jsonrpc.core.JsonRpcMethod;
 import com.limehee.jsonrpc.core.JsonRpcMethodRegistration;
@@ -663,6 +664,50 @@ class JsonRpcAutoConfigurationTest {
     }
 
     @Test
+    void enforcesRequireIdMemberForNotificationLikeRequestWhenConfigured() {
+        contextRunner
+            .withPropertyValues("jsonrpc.validation.request.require-id-member=true")
+            .withBean("ping", JsonRpcMethodRegistration.class,
+                () -> JsonRpcMethodRegistration.of("ping", params -> StringNode.valueOf("pong")))
+            .run(context -> {
+                JsonRpcDispatcher dispatcher = context.getBean(JsonRpcDispatcher.class);
+                JsonRpcResponse response = dispatcher.dispatch(new JsonRpcRequest(
+                    "2.0",
+                    null,
+                    "ping",
+                    null,
+                    false
+                ));
+
+                assertNotNull(response.error());
+                assertEquals(-32600, response.error().code());
+                assertNull(response.id());
+            });
+    }
+
+    @Test
+    void enforcesRejectResponseFieldsForRequestWhenConfigured() throws Exception {
+        contextRunner
+            .withPropertyValues("jsonrpc.validation.request.reject-response-fields=true")
+            .withBean("ping", JsonRpcMethodRegistration.class,
+                () -> JsonRpcMethodRegistration.of("ping", params -> StringNode.valueOf("pong")))
+            .run(context -> {
+                JsonRpcDispatcher dispatcher = context.getBean(JsonRpcDispatcher.class);
+                JsonRpcResponse response = dispatcher.dispatch(new JsonRpcRequest(
+                    "2.0",
+                    IntNode.valueOf(41),
+                    "ping",
+                    null,
+                    true,
+                    new ObjectMapper().readTree("{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"id\":41,\"result\":1}")
+                ));
+
+                assertNotNull(response.error());
+                assertEquals(-32600, response.error().code());
+            });
+    }
+
+    @Test
     void bindsDefaultResponseValidationOptions() {
         contextRunner.run(context -> {
             JsonRpcResponseValidationOptions options = context.getBean(JsonRpcResponseValidationOptions.class);
@@ -707,6 +752,28 @@ class JsonRpcAutoConfigurationTest {
                 assertTrue(options.errorCodePolicy() == JsonRpcResponseErrorCodePolicy.CUSTOM_RANGE);
                 assertEquals(-45000, options.errorCodeRangeMin());
                 assertEquals(-44000, options.errorCodeRangeMax());
+            });
+    }
+
+    @Test
+    void appliesStandardOnlyErrorCodePolicyToResponseValidatorBean() {
+        contextRunner
+            .withPropertyValues("jsonrpc.validation.response.error-code.policy=STANDARD_ONLY")
+            .run(context -> {
+                JsonRpcResponseValidator validator = context.getBean(JsonRpcResponseValidator.class);
+                DefaultJsonRpcResponseParser parser = new DefaultJsonRpcResponseParser();
+
+                JsonRpcIncomingResponse standard = parser
+                    .parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32603,\"message\":\"x\"}}")
+                    .singleResponse()
+                    .orElseThrow();
+                JsonRpcIncomingResponse nonStandard = parser
+                    .parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"x\"}}")
+                    .singleResponse()
+                    .orElseThrow();
+
+                validator.validate(standard);
+                assertThrows(JsonRpcException.class, () -> validator.validate(nonStandard));
             });
     }
 

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcMetricsInterceptorTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcMetricsInterceptorTest.java
@@ -1,0 +1,137 @@
+package com.limehee.jsonrpc.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.limehee.jsonrpc.core.JsonRpcError;
+import com.limehee.jsonrpc.core.JsonRpcErrorCode;
+import com.limehee.jsonrpc.core.JsonRpcRequest;
+import com.limehee.jsonrpc.spring.boot.autoconfigure.support.JsonRpcMetricsInterceptor;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.StringNode;
+
+class JsonRpcMetricsInterceptorTest {
+
+    @Test
+    void classifiesMethodNotFoundAsResolutionForNonAccessControlThrowable() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        JsonRpcMetricsInterceptor interceptor = new JsonRpcMetricsInterceptor(meterRegistry);
+        JsonRpcRequest request = request("lookup");
+
+        interceptor.beforeInvoke(request);
+        interceptor.onError(request, new IllegalStateException("missing"),
+            JsonRpcError.of(JsonRpcErrorCode.METHOD_NOT_FOUND, "Method not found"));
+
+        assertEquals(1.0, meterRegistry.counter(
+            "jsonrpc.server.stage.events",
+            "method", "lookup",
+            "stage", "method_not_found"
+        ).count());
+        assertEquals(1.0, meterRegistry.counter(
+            "jsonrpc.server.failures",
+            "method", "lookup",
+            "errorCode", "-32601",
+            "source", "resolution"
+        ).count());
+    }
+
+    @Test
+    void classifiesInternalErrorAsHandlerForNonInterceptorThrowable() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        JsonRpcMetricsInterceptor interceptor = new JsonRpcMetricsInterceptor(meterRegistry);
+        JsonRpcRequest request = request("explode");
+
+        interceptor.beforeInvoke(request);
+        interceptor.onError(request, new IllegalStateException("boom"),
+            JsonRpcError.of(JsonRpcErrorCode.INTERNAL_ERROR, "Internal error"));
+
+        assertEquals(1.0, meterRegistry.counter(
+            "jsonrpc.server.stage.events",
+            "method", "explode",
+            "stage", "internal_error"
+        ).count());
+        assertEquals(1.0, meterRegistry.counter(
+            "jsonrpc.server.failures",
+            "method", "explode",
+            "errorCode", "-32603",
+            "source", "handler"
+        ).count());
+    }
+
+    @Test
+    void classifiesCustomCodeAsCustomStageAndSource() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        JsonRpcMetricsInterceptor interceptor = new JsonRpcMetricsInterceptor(meterRegistry);
+        JsonRpcRequest request = request("domain.error");
+
+        interceptor.beforeInvoke(request);
+        interceptor.onError(request, new IllegalArgumentException("domain"),
+            JsonRpcError.of(-32010, "Domain error"));
+
+        assertEquals(1.0, meterRegistry.counter(
+            "jsonrpc.server.stage.events",
+            "method", "domain.error",
+            "stage", "custom_error"
+        ).count());
+        assertEquals(1.0, meterRegistry.counter(
+            "jsonrpc.server.failures",
+            "method", "domain.error",
+            "errorCode", "-32010",
+            "source", "custom"
+        ).count());
+    }
+
+    @Test
+    void usesUnknownMethodTagWhenRequestIsMissing() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        JsonRpcMetricsInterceptor interceptor = new JsonRpcMetricsInterceptor(meterRegistry);
+
+        interceptor.onError(null, new IllegalStateException("boom"),
+            JsonRpcError.of(JsonRpcErrorCode.INTERNAL_ERROR, "Internal error"));
+
+        assertEquals(1.0, meterRegistry.counter(
+            "jsonrpc.server.calls",
+            "method", "unknown",
+            "outcome", "error",
+            "errorCode", "-32603"
+        ).count());
+    }
+
+    @Test
+    void doesNotCollapseMethodTagsWhenCardinalityLimitIsDisabled() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        JsonRpcMetricsInterceptor interceptor = new JsonRpcMetricsInterceptor(
+            meterRegistry,
+            false,
+            new double[0],
+            0
+        );
+        JsonRpcRequest first = request("method.a");
+        JsonRpcRequest second = request("method.b");
+
+        interceptor.beforeInvoke(first);
+        interceptor.afterInvoke(first, StringNode.valueOf("a"));
+
+        interceptor.beforeInvoke(second);
+        interceptor.afterInvoke(second, StringNode.valueOf("b"));
+
+        assertEquals(1.0, meterRegistry.counter(
+            "jsonrpc.server.calls",
+            "method", "method.a",
+            "outcome", "success",
+            "errorCode", "none"
+        ).count());
+        assertEquals(1.0, meterRegistry.counter(
+            "jsonrpc.server.calls",
+            "method", "method.b",
+            "outcome", "success",
+            "errorCode", "none"
+        ).count());
+    }
+
+    private JsonRpcRequest request(String method) {
+        return new JsonRpcRequest("2.0", IntNode.valueOf(1), method, null, true);
+    }
+}

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcMetricsInterceptorTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcMetricsInterceptorTest.java
@@ -1,6 +1,7 @@
 package com.limehee.jsonrpc.spring.boot.autoconfigure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.limehee.jsonrpc.core.JsonRpcError;
 import com.limehee.jsonrpc.core.JsonRpcErrorCode;
@@ -10,7 +11,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.IntNode;
-import tools.jackson.databind.node.StringNode;
 
 class JsonRpcMetricsInterceptorTest {
 
@@ -100,35 +100,16 @@ class JsonRpcMetricsInterceptorTest {
     }
 
     @Test
-    void doesNotCollapseMethodTagsWhenCardinalityLimitIsDisabled() {
+    void rejectsNonPositiveMaxMethodTagValues() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
-        JsonRpcMetricsInterceptor interceptor = new JsonRpcMetricsInterceptor(
-            meterRegistry,
-            false,
-            new double[0],
-            0
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new JsonRpcMetricsInterceptor(meterRegistry, false, new double[0], 0)
         );
-        JsonRpcRequest first = request("method.a");
-        JsonRpcRequest second = request("method.b");
-
-        interceptor.beforeInvoke(first);
-        interceptor.afterInvoke(first, StringNode.valueOf("a"));
-
-        interceptor.beforeInvoke(second);
-        interceptor.afterInvoke(second, StringNode.valueOf("b"));
-
-        assertEquals(1.0, meterRegistry.counter(
-            "jsonrpc.server.calls",
-            "method", "method.a",
-            "outcome", "success",
-            "errorCode", "none"
-        ).count());
-        assertEquals(1.0, meterRegistry.counter(
-            "jsonrpc.server.calls",
-            "method", "method.b",
-            "outcome", "success",
-            "errorCode", "none"
-        ).count());
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new JsonRpcMetricsInterceptor(meterRegistry, false, new double[0], -1)
+        );
     }
 
     private JsonRpcRequest request(String method) {

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcMetricsInterceptorTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcMetricsInterceptorTest.java
@@ -2,6 +2,7 @@ package com.limehee.jsonrpc.spring.boot.autoconfigure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.limehee.jsonrpc.core.JsonRpcError;
 import com.limehee.jsonrpc.core.JsonRpcErrorCode;
@@ -9,6 +10,13 @@ import com.limehee.jsonrpc.core.JsonRpcRequest;
 import com.limehee.jsonrpc.spring.boot.autoconfigure.support.JsonRpcMetricsInterceptor;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.IntNode;
 
@@ -110,6 +118,49 @@ class JsonRpcMetricsInterceptorTest {
             IllegalArgumentException.class,
             () -> new JsonRpcMetricsInterceptor(meterRegistry, false, new double[0], -1)
         );
+    }
+
+    @Test
+    void enforcesHardCapForDistinctMethodTagsUnderConcurrency() throws Exception {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        JsonRpcMetricsInterceptor interceptor = new JsonRpcMetricsInterceptor(meterRegistry, false, new double[0], 1);
+        int workers = 64;
+        ExecutorService executor = Executors.newFixedThreadPool(workers);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>(workers);
+        for (int i = 0; i < workers; i++) {
+            String methodName = "method." + i;
+            futures.add(executor.submit(() -> {
+                start.await();
+                JsonRpcRequest request = request(methodName);
+                interceptor.beforeInvoke(request);
+                interceptor.afterInvoke(request, IntNode.valueOf(1));
+                return null;
+            }));
+        }
+
+        start.countDown();
+        for (Future<?> future : futures) {
+            future.get();
+        }
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+
+        long concreteMethodTags = meterRegistry.getMeters().stream()
+            .filter(meter -> "jsonrpc.server.calls".equals(meter.getId().getName()))
+            .map(meter -> meter.getId().getTag("method"))
+            .filter(method -> method != null && !"other".equals(method) && !"unknown".equals(method))
+            .distinct()
+            .count();
+
+        assertEquals(1, concreteMethodTags);
+        assertEquals(63, meterRegistry.counter(
+            "jsonrpc.server.calls",
+            "method", "other",
+            "outcome", "success",
+            "errorCode", "none"
+        ).count(), 0.0d);
     }
 
     private JsonRpcRequest request(String method) {

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcWebAutoConfigurationTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcWebAutoConfigurationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.limehee.jsonrpc.core.JsonRpcRequestValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponse;
 import com.limehee.jsonrpc.spring.webmvc.JsonRpcHttpStatusStrategy;
 import com.limehee.jsonrpc.spring.webmvc.JsonRpcWebMvcEndpoint;
@@ -92,6 +93,50 @@ class JsonRpcWebAutoConfigurationTest {
                 assertNotNull(body);
                 int code = OBJECT_MAPPER.readTree(body).get("error").get("code").asInt();
                 assertEquals(-32700, code);
+            });
+    }
+
+    @Test
+    void customRequestValidationOptionsCanEnableDuplicateMemberRejectionEvenWhenPropertyIsDisabled() throws Exception {
+        webContextRunner
+            .withPropertyValues("jsonrpc.validation.request.reject-duplicate-members=false")
+            .withBean(
+                JsonRpcRequestValidationOptions.class,
+                () -> JsonRpcRequestValidationOptions.builder()
+                    .rejectDuplicateMembers(true)
+                    .build()
+            )
+            .run(context -> {
+                JsonRpcWebMvcEndpoint endpoint = context.getBean(JsonRpcWebMvcEndpoint.class);
+                String body = endpoint.invoke(
+                    "{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"id\":1,\"id\":2}".getBytes(StandardCharsets.UTF_8)
+                ).getBody();
+
+                assertNotNull(body);
+                int code = OBJECT_MAPPER.readTree(body).get("error").get("code").asInt();
+                assertEquals(-32700, code);
+            });
+    }
+
+    @Test
+    void customRequestValidationOptionsCanDisableDuplicateMemberRejectionEvenWhenPropertyIsEnabled() throws Exception {
+        webContextRunner
+            .withPropertyValues("jsonrpc.validation.request.reject-duplicate-members=true")
+            .withBean(
+                JsonRpcRequestValidationOptions.class,
+                () -> JsonRpcRequestValidationOptions.builder()
+                    .rejectDuplicateMembers(false)
+                    .build()
+            )
+            .run(context -> {
+                JsonRpcWebMvcEndpoint endpoint = context.getBean(JsonRpcWebMvcEndpoint.class);
+                String body = endpoint.invoke(
+                    "{\"jsonrpc\":\"2.0\",\"method\":\"missing\",\"id\":1,\"id\":2}".getBytes(StandardCharsets.UTF_8)
+                ).getBody();
+
+                assertNotNull(body);
+                int code = OBJECT_MAPPER.readTree(body).get("error").get("code").asInt();
+                assertEquals(-32601, code);
             });
     }
 

--- a/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcWebAutoConfigurationTest.java
+++ b/jsonrpc-spring-boot-autoconfigure/src/test/java/com/limehee/jsonrpc/spring/boot/autoconfigure/JsonRpcWebAutoConfigurationTest.java
@@ -18,8 +18,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 class JsonRpcWebAutoConfigurationTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
     private final WebApplicationContextRunner webContextRunner = new WebApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(JsonRpcAutoConfiguration.class));
@@ -59,6 +63,36 @@ class JsonRpcWebAutoConfigurationTest {
         webContextRunner
             .withPropertyValues("jsonrpc.max-request-bytes=0")
             .run(context -> assertNotNull(context.getStartupFailure()));
+    }
+
+    @Test
+    void keepsRequestDuplicateMemberAcceptanceWhenRequestPolicyIsDisabled() throws Exception {
+        webContextRunner
+            .withPropertyValues("jsonrpc.validation.request.reject-duplicate-members=false")
+            .run(context -> {
+                JsonRpcWebMvcEndpoint endpoint = context.getBean(JsonRpcWebMvcEndpoint.class);
+                HttpStatusCode status = endpoint.invoke(
+                    "{\"jsonrpc\":\"2.0\",\"method\":\"missing\",\"id\":1,\"id\":2}".getBytes(StandardCharsets.UTF_8)
+                ).getStatusCode();
+
+                assertEquals(HttpStatus.OK.value(), status.value());
+            });
+    }
+
+    @Test
+    void rejectsRequestDuplicateMembersWhenRequestPolicyIsEnabled() throws Exception {
+        webContextRunner
+            .withPropertyValues("jsonrpc.validation.request.reject-duplicate-members=true")
+            .run(context -> {
+                JsonRpcWebMvcEndpoint endpoint = context.getBean(JsonRpcWebMvcEndpoint.class);
+                String body = endpoint.invoke(
+                    "{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"id\":1,\"id\":2}".getBytes(StandardCharsets.UTF_8)
+                ).getBody();
+
+                assertNotNull(body);
+                int code = OBJECT_MAPPER.readTree(body).get("error").get("code").asInt();
+                assertEquals(-32700, code);
+            });
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/jsonrpc-spring-webmvc/src/main/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpoint.java
+++ b/jsonrpc-spring-webmvc/src/main/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpoint.java
@@ -90,12 +90,12 @@ public class JsonRpcWebMvcEndpoint {
     /**
      * Creates an endpoint with explicit transport observer and request duplicate-member policy.
      *
-     * @param dispatcher               dispatcher that performs JSON-RPC parsing, validation, and invocation
-     * @param objectMapper             mapper used to parse request payloads and serialize responses
-     * @param httpStatusStrategy       strategy that maps JSON-RPC outcomes to HTTP status codes
-     * @param maxRequestBytes          maximum accepted request payload size in bytes
-     * @param observer                 observer receiving transport-level event callbacks
-     * @param rejectDuplicateMembers   {@code true} to reject duplicate request members during JSON parsing
+     * @param dispatcher             dispatcher that performs JSON-RPC parsing, validation, and invocation
+     * @param objectMapper           mapper used to parse request payloads and serialize responses
+     * @param httpStatusStrategy     strategy that maps JSON-RPC outcomes to HTTP status codes
+     * @param maxRequestBytes        maximum accepted request payload size in bytes
+     * @param observer               observer receiving transport-level event callbacks
+     * @param rejectDuplicateMembers {@code true} to reject duplicate request members during JSON parsing
      * @throws IllegalArgumentException if {@code maxRequestBytes <= 0}
      */
     public JsonRpcWebMvcEndpoint(

--- a/jsonrpc-spring-webmvc/src/main/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpoint.java
+++ b/jsonrpc-spring-webmvc/src/main/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpoint.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.core.StreamReadFeature;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -28,6 +29,7 @@ public class JsonRpcWebMvcEndpoint {
 
     private final JsonRpcDispatcher dispatcher;
     private final ObjectMapper objectMapper;
+    private final ObjectMapper requestObjectMapper;
     private final JsonRpcHttpStatusStrategy httpStatusStrategy;
     private final int maxRequestBytes;
     private final JsonRpcWebMvcObserver observer;
@@ -51,7 +53,8 @@ public class JsonRpcWebMvcEndpoint {
             objectMapper,
             httpStatusStrategy,
             maxRequestBytes,
-            JsonRpcWebMvcObserver.noOp()
+            JsonRpcWebMvcObserver.noOp(),
+            false
         );
     }
 
@@ -71,8 +74,39 @@ public class JsonRpcWebMvcEndpoint {
         int maxRequestBytes,
         JsonRpcWebMvcObserver observer
     ) {
+        this(
+            dispatcher,
+            objectMapper,
+            httpStatusStrategy,
+            maxRequestBytes,
+            observer,
+            false
+        );
+    }
+
+    /**
+     * Creates an endpoint with explicit transport observer and request duplicate-member policy.
+     *
+     * @param dispatcher               dispatcher that performs JSON-RPC parsing, validation, and invocation
+     * @param objectMapper             mapper used to parse request payloads and serialize responses
+     * @param httpStatusStrategy       strategy that maps JSON-RPC outcomes to HTTP status codes
+     * @param maxRequestBytes          maximum accepted request payload size in bytes
+     * @param observer                 observer receiving transport-level event callbacks
+     * @param rejectDuplicateMembers   {@code true} to reject duplicate request members during JSON parsing
+     */
+    public JsonRpcWebMvcEndpoint(
+        JsonRpcDispatcher dispatcher,
+        ObjectMapper objectMapper,
+        JsonRpcHttpStatusStrategy httpStatusStrategy,
+        int maxRequestBytes,
+        JsonRpcWebMvcObserver observer,
+        boolean rejectDuplicateMembers
+    ) {
         this.dispatcher = dispatcher;
         this.objectMapper = objectMapper;
+        this.requestObjectMapper = rejectDuplicateMembers
+            ? objectMapper.rebuild().enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION).build()
+            : objectMapper;
         this.httpStatusStrategy = httpStatusStrategy;
         this.maxRequestBytes = maxRequestBytes;
         this.observer = observer;
@@ -114,7 +148,7 @@ public class JsonRpcWebMvcEndpoint {
 
         JsonNode payload;
         try {
-            payload = objectMapper.readTree(body);
+            payload = requestObjectMapper.readTree(body);
         } catch (JacksonException ex) {
             observer.onParseError();
             return singleErrorResponse(dispatcher.parseErrorResponse(), httpStatusStrategy.statusForParseError());

--- a/jsonrpc-spring-webmvc/src/main/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpoint.java
+++ b/jsonrpc-spring-webmvc/src/main/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpoint.java
@@ -3,6 +3,7 @@ package com.limehee.jsonrpc.spring.webmvc;
 import com.limehee.jsonrpc.core.JsonRpcDispatchResult;
 import com.limehee.jsonrpc.core.JsonRpcDispatcher;
 import com.limehee.jsonrpc.core.JsonRpcErrorCode;
+import com.limehee.jsonrpc.core.JsonRpcPayloadReader;
 import com.limehee.jsonrpc.core.JsonRpcResponse;
 import java.util.List;
 import java.util.Objects;
@@ -12,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import tools.jackson.core.StreamReadFeature;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -30,7 +30,7 @@ public class JsonRpcWebMvcEndpoint {
 
     private final JsonRpcDispatcher dispatcher;
     private final ObjectMapper objectMapper;
-    private final ObjectMapper requestObjectMapper;
+    private final JsonRpcPayloadReader requestPayloadReader;
     private final JsonRpcHttpStatusStrategy httpStatusStrategy;
     private final int maxRequestBytes;
     private final JsonRpcWebMvcObserver observer;
@@ -111,9 +111,7 @@ public class JsonRpcWebMvcEndpoint {
         if (maxRequestBytes <= 0) {
             throw new IllegalArgumentException("maxRequestBytes must be greater than 0");
         }
-        this.requestObjectMapper = rejectDuplicateMembers
-            ? objectMapper.rebuild().enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION).build()
-            : objectMapper;
+        this.requestPayloadReader = new JsonRpcPayloadReader(objectMapper, rejectDuplicateMembers);
         this.httpStatusStrategy = Objects.requireNonNull(httpStatusStrategy, "httpStatusStrategy");
         this.maxRequestBytes = maxRequestBytes;
         this.observer = Objects.requireNonNull(observer, "observer");
@@ -155,7 +153,7 @@ public class JsonRpcWebMvcEndpoint {
 
         JsonNode payload;
         try {
-            payload = requestObjectMapper.readTree(body);
+            payload = requestPayloadReader.readTree(body);
         } catch (JacksonException ex) {
             observer.onParseError();
             return singleErrorResponse(dispatcher.parseErrorResponse(), httpStatusStrategy.statusForParseError());

--- a/jsonrpc-spring-webmvc/src/main/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpoint.java
+++ b/jsonrpc-spring-webmvc/src/main/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpoint.java
@@ -5,6 +5,7 @@ import com.limehee.jsonrpc.core.JsonRpcDispatcher;
 import com.limehee.jsonrpc.core.JsonRpcErrorCode;
 import com.limehee.jsonrpc.core.JsonRpcResponse;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -41,6 +42,7 @@ public class JsonRpcWebMvcEndpoint {
      * @param objectMapper       mapper used to parse request payloads and serialize responses
      * @param httpStatusStrategy strategy that maps JSON-RPC outcomes to HTTP status codes
      * @param maxRequestBytes    maximum accepted request payload size in bytes
+     * @throws IllegalArgumentException if {@code maxRequestBytes <= 0}
      */
     public JsonRpcWebMvcEndpoint(
         JsonRpcDispatcher dispatcher,
@@ -66,6 +68,7 @@ public class JsonRpcWebMvcEndpoint {
      * @param httpStatusStrategy strategy that maps JSON-RPC outcomes to HTTP status codes
      * @param maxRequestBytes    maximum accepted request payload size in bytes
      * @param observer           observer receiving transport-level event callbacks
+     * @throws IllegalArgumentException if {@code maxRequestBytes <= 0}
      */
     public JsonRpcWebMvcEndpoint(
         JsonRpcDispatcher dispatcher,
@@ -93,6 +96,7 @@ public class JsonRpcWebMvcEndpoint {
      * @param maxRequestBytes          maximum accepted request payload size in bytes
      * @param observer                 observer receiving transport-level event callbacks
      * @param rejectDuplicateMembers   {@code true} to reject duplicate request members during JSON parsing
+     * @throws IllegalArgumentException if {@code maxRequestBytes <= 0}
      */
     public JsonRpcWebMvcEndpoint(
         JsonRpcDispatcher dispatcher,
@@ -102,14 +106,17 @@ public class JsonRpcWebMvcEndpoint {
         JsonRpcWebMvcObserver observer,
         boolean rejectDuplicateMembers
     ) {
-        this.dispatcher = dispatcher;
-        this.objectMapper = objectMapper;
+        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+        if (maxRequestBytes <= 0) {
+            throw new IllegalArgumentException("maxRequestBytes must be greater than 0");
+        }
         this.requestObjectMapper = rejectDuplicateMembers
             ? objectMapper.rebuild().enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION).build()
             : objectMapper;
-        this.httpStatusStrategy = httpStatusStrategy;
+        this.httpStatusStrategy = Objects.requireNonNull(httpStatusStrategy, "httpStatusStrategy");
         this.maxRequestBytes = maxRequestBytes;
-        this.observer = observer;
+        this.observer = Objects.requireNonNull(observer, "observer");
     }
 
     /**

--- a/jsonrpc-spring-webmvc/src/test/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpointTest.java
+++ b/jsonrpc-spring-webmvc/src/test/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpointTest.java
@@ -191,6 +191,45 @@ class JsonRpcWebMvcEndpointTest {
     }
 
     @Test
+    void allowsDuplicateRequestMembersWhenDuplicateRejectionIsDisabled() throws Exception {
+        MvcResult result = mockMvc.perform(post("/jsonrpc")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"id\":1,\"id\":2}"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonRpcResponse response = OBJECT_MAPPER.readValue(result.getResponse().getContentAsByteArray(),
+            JsonRpcResponse.class);
+        assertEquals("pong", response.result().asString());
+        assertEquals(2, response.id().asInt());
+    }
+
+    @Test
+    void rejectsDuplicateRequestMembersWhenDuplicateRejectionIsEnabled() throws Exception {
+        JsonRpcDispatcher dispatcher = new JsonRpcDispatcher();
+        dispatcher.register("ping", params -> StringNode.valueOf("pong"));
+        JsonRpcWebMvcEndpoint endpoint = new JsonRpcWebMvcEndpoint(
+            dispatcher,
+            OBJECT_MAPPER,
+            new DefaultJsonRpcHttpStatusStrategy(),
+            1024 * 1024,
+            JsonRpcWebMvcObserver.noOp(),
+            true
+        );
+        MockMvc localMockMvc = MockMvcBuilders.standaloneSetup(endpoint).build();
+
+        MvcResult result = localMockMvc.perform(post("/jsonrpc")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"id\":1,\"id\":2}"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonRpcResponse response = OBJECT_MAPPER.readValue(result.getResponse().getContentAsByteArray(),
+            JsonRpcResponse.class);
+        assertEquals(JsonRpcErrorCode.PARSE_ERROR, response.error().code());
+    }
+
+    @Test
     void usesCustomStatusStrategyForParseErrorAndPayloadLimit() throws Exception {
         JsonRpcDispatcher dispatcher = new JsonRpcDispatcher();
         dispatcher.register("ping", params -> StringNode.valueOf("pong"));

--- a/jsonrpc-spring-webmvc/src/test/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpointTest.java
+++ b/jsonrpc-spring-webmvc/src/test/java/com/limehee/jsonrpc/spring/webmvc/JsonRpcWebMvcEndpointTest.java
@@ -1,6 +1,7 @@
 package com.limehee.jsonrpc.spring.webmvc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -347,6 +348,25 @@ class JsonRpcWebMvcEndpointTest {
         assertEquals(1, observer.batchResponses);
         assertEquals(3, observer.lastBatchRequestCount);
         assertEquals(2, observer.lastBatchResponseCount);
+    }
+
+    @Test
+    void constructorRejectsNonPositiveMaxRequestBytes() {
+        JsonRpcDispatcher dispatcher = new JsonRpcDispatcher();
+
+        assertThrows(IllegalArgumentException.class, () -> new JsonRpcWebMvcEndpoint(
+            dispatcher,
+            OBJECT_MAPPER,
+            new DefaultJsonRpcHttpStatusStrategy(),
+            0
+        ));
+
+        assertThrows(IllegalArgumentException.class, () -> new JsonRpcWebMvcEndpoint(
+            dispatcher,
+            OBJECT_MAPPER,
+            new DefaultJsonRpcHttpStatusStrategy(),
+            -1
+        ));
     }
 
     private static final class RecordingObserver implements JsonRpcWebMvcObserver {

--- a/samples/pure-java-demo/README.md
+++ b/samples/pure-java-demo/README.md
@@ -10,6 +10,14 @@ From repository root:
 ./gradlew -p samples/pure-java-demo run
 ```
 
+## Run Tests
+
+From repository root:
+
+```bash
+./gradlew -p samples/pure-java-demo test
+```
+
 ## What This Demo Covers
 
 - Single request success flow

--- a/samples/pure-java-demo/README.md
+++ b/samples/pure-java-demo/README.md
@@ -19,6 +19,10 @@ From repository root:
 - Typed handler registration (`JsonRpcTypedMethodHandlerFactory`)
 - Manual handler registration (`dispatcher.register`)
 - Request-validator policy switch with `JsonRpcParamsTypeViolationCodePolicy`
+- Request validation profile with `JsonRpcRequestValidationOptions` (`require-id-member`, `allow-fractional-id`,
+  `reject-response-fields`)
+- Response validation profile with `JsonRpcResponseValidationOptions` (`reject-request-fields`,
+  `reject-duplicate-members`, `error-code.policy`)
 - Incoming response-side flow using classifier/parser/validator utilities
 - Interceptor lifecycle flow (`beforeValidate`, `beforeInvoke`, `afterInvoke`, `onError`)
 
@@ -27,5 +31,6 @@ From repository root:
 - `src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java`
 - `src/main/java/com/limehee/jsonrpc/sample/purejava/ResponseSideUtilitiesExample.java`
 - `src/main/java/com/limehee/jsonrpc/sample/purejava/InterceptorFlowExample.java`
+- `src/main/java/com/limehee/jsonrpc/sample/purejava/ValidationProfileExample.java`
 
 The `main` method prints one output payload per scenario so you can follow request -> dispatch -> response flow.

--- a/samples/pure-java-demo/build.gradle
+++ b/samples/pure-java-demo/build.gradle
@@ -6,6 +6,15 @@ plugins {
 group = 'com.limehee.jsonrpc'
 version = '0.0.1-SNAPSHOT'
 
+def jsonrpcVersion = providers.gradleProperty('jsonrpcVersion')
+    .orElse(providers.environmentVariable('JSONRPC_VERSION'))
+    .orElse(providers.provider {
+        def props = new Properties()
+        file('../../gradle.properties').withInputStream { props.load(it) }
+        props.getProperty('version', '0.0.0-SNAPSHOT')
+    })
+    .get()
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
@@ -13,7 +22,7 @@ java {
 }
 
 dependencies {
-    implementation 'io.github.limehee:jsonrpc-core:0.2.0'
+    implementation "io.github.limehee:jsonrpc-core:${jsonrpcVersion}"
     implementation 'tools.jackson.core:jackson-databind:3.1.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:6.0.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.0.3'

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
@@ -16,6 +16,7 @@ import com.limehee.jsonrpc.core.JacksonJsonRpcParameterBinder;
 import com.limehee.jsonrpc.core.JacksonJsonRpcResultWriter;
 import com.limehee.jsonrpc.core.JsonRpcDispatchResult;
 import com.limehee.jsonrpc.core.JsonRpcDispatcher;
+import com.limehee.jsonrpc.core.JsonRpcIncomingResponse;
 import com.limehee.jsonrpc.core.JsonRpcMethodRegistrationConflictPolicy;
 import com.limehee.jsonrpc.core.JsonRpcParamsTypeViolationCodePolicy;
 import com.limehee.jsonrpc.core.JsonRpcTypedMethodHandlerFactory;
@@ -52,6 +53,18 @@ public final class PureJavaDemoApplication {
         print("strict params shape policy", handle(strictDispatcher, """
             {"jsonrpc":"2.0","method":"typed.upper","params":"invalid-shape","id":9}
             """));
+
+        JsonRpcDispatchResult strictRequestResult = ValidationProfileExample.dispatchStrict("""
+            {"jsonrpc":"2.0","method":"ping"}
+            """);
+        print("strict request profile (require-id-member)", OBJECT_MAPPER.writeValueAsString(
+            strictRequestResult.singleResponse().orElseThrow()
+        ));
+
+        List<JsonRpcIncomingResponse> strictResponses = ValidationProfileExample.parseAndValidateStrictResponses("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"server"}}
+            """);
+        print("strict response profile", OBJECT_MAPPER.writeValueAsString(strictResponses));
     }
 
     static String handle(JsonRpcDispatcher dispatcher, String rawJson) throws JacksonException {

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/ResponseSideUtilitiesExample.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/ResponseSideUtilitiesExample.java
@@ -11,7 +11,6 @@ import com.limehee.jsonrpc.core.JsonRpcEnvelopeClassifier;
 import com.limehee.jsonrpc.core.JsonRpcEnvelopeType;
 import com.limehee.jsonrpc.core.JsonRpcIncomingResponse;
 import com.limehee.jsonrpc.core.JsonRpcIncomingResponseEnvelope;
-import com.limehee.jsonrpc.core.JsonRpcResponseParser;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidationOptions;
 import com.limehee.jsonrpc.core.JsonRpcResponseValidator;
 
@@ -23,12 +22,12 @@ public final class ResponseSideUtilitiesExample {
     private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
     private final JsonRpcEnvelopeClassifier classifier;
-    private final JsonRpcResponseParser parser;
+    private final DefaultJsonRpcResponseParser parser;
     private final JsonRpcResponseValidator validator;
 
     public ResponseSideUtilitiesExample(JsonRpcResponseValidationOptions options) {
         this.classifier = new DefaultJsonRpcEnvelopeClassifier();
-        this.parser = new DefaultJsonRpcResponseParser();
+        this.parser = new DefaultJsonRpcResponseParser(options.rejectDuplicateMembers());
         this.validator = new DefaultJsonRpcResponseValidator(options);
     }
 
@@ -39,7 +38,7 @@ public final class ResponseSideUtilitiesExample {
             return new Result(envelopeType, List.of());
         }
 
-        JsonRpcIncomingResponseEnvelope envelope = parser.parse(payload);
+        JsonRpcIncomingResponseEnvelope envelope = parser.parse(rawMessage);
         List<JsonRpcIncomingResponse> validated = new ArrayList<>(envelope.responses().size());
         for (JsonRpcIncomingResponse response : envelope.responses()) {
             validator.validate(response);

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/ValidationProfileExample.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/ValidationProfileExample.java
@@ -1,0 +1,100 @@
+package com.limehee.jsonrpc.sample.purejava;
+
+import com.limehee.jsonrpc.core.DefaultJsonRpcExceptionResolver;
+import com.limehee.jsonrpc.core.DefaultJsonRpcMethodInvoker;
+import com.limehee.jsonrpc.core.DefaultJsonRpcRequestParser;
+import com.limehee.jsonrpc.core.DefaultJsonRpcRequestValidator;
+import com.limehee.jsonrpc.core.DefaultJsonRpcResponseComposer;
+import com.limehee.jsonrpc.core.DefaultJsonRpcResponseParser;
+import com.limehee.jsonrpc.core.DefaultJsonRpcResponseValidator;
+import com.limehee.jsonrpc.core.DirectJsonRpcNotificationExecutor;
+import com.limehee.jsonrpc.core.InMemoryJsonRpcMethodRegistry;
+import com.limehee.jsonrpc.core.JsonRpcDispatchResult;
+import com.limehee.jsonrpc.core.JsonRpcDispatcher;
+import com.limehee.jsonrpc.core.JsonRpcIncomingResponse;
+import com.limehee.jsonrpc.core.JsonRpcIncomingResponseEnvelope;
+import com.limehee.jsonrpc.core.JsonRpcMethodRegistrationConflictPolicy;
+import com.limehee.jsonrpc.core.JsonRpcParamsTypeViolationCodePolicy;
+import com.limehee.jsonrpc.core.JsonRpcRequestValidationOptions;
+import com.limehee.jsonrpc.core.JsonRpcResponseErrorCodePolicy;
+import com.limehee.jsonrpc.core.JsonRpcResponseValidationOptions;
+import java.util.ArrayList;
+import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.StringNode;
+
+public final class ValidationProfileExample {
+
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
+
+    private ValidationProfileExample() {
+    }
+
+    public static JsonRpcRequestValidationOptions strictRequestOptions() {
+        return JsonRpcRequestValidationOptions.builder()
+            .requireJsonRpcVersion20(true)
+            .requireIdMember(true)
+            .allowNullId(false)
+            .allowStringId(true)
+            .allowNumericId(true)
+            .allowFractionalId(false)
+            .rejectResponseFields(true)
+            .paramsTypeViolationCodePolicy(JsonRpcParamsTypeViolationCodePolicy.INVALID_REQUEST)
+            .build();
+    }
+
+    public static JsonRpcResponseValidationOptions strictResponseOptions() {
+        return JsonRpcResponseValidationOptions.builder()
+            .requireJsonRpcVersion20(true)
+            .requireIdMember(true)
+            .allowNullId(false)
+            .allowStringId(true)
+            .allowNumericId(true)
+            .allowFractionalId(false)
+            .requireExclusiveResultOrError(true)
+            .requireErrorObjectWhenPresent(true)
+            .requireIntegerErrorCode(true)
+            .requireStringErrorMessage(true)
+            .rejectRequestFields(true)
+            .rejectDuplicateMembers(true)
+            .errorCodePolicy(JsonRpcResponseErrorCodePolicy.STANDARD_OR_SERVER_ERROR_RANGE)
+            .build();
+    }
+
+    public static JsonRpcDispatcher createStrictDispatcher() {
+        JsonRpcDispatcher dispatcher = new JsonRpcDispatcher(
+            new InMemoryJsonRpcMethodRegistry(JsonRpcMethodRegistrationConflictPolicy.REJECT),
+            new DefaultJsonRpcRequestParser(),
+            new DefaultJsonRpcRequestValidator(strictRequestOptions()),
+            new DefaultJsonRpcMethodInvoker(),
+            new DefaultJsonRpcExceptionResolver(false),
+            new DefaultJsonRpcResponseComposer(),
+            100,
+            List.of(),
+            new DirectJsonRpcNotificationExecutor()
+        );
+        dispatcher.register("ping", params -> StringNode.valueOf("pong"));
+        return dispatcher;
+    }
+
+    public static JsonRpcDispatchResult dispatchStrict(String rawRequest) throws JacksonException {
+        JsonRpcDispatcher dispatcher = createStrictDispatcher();
+        return dispatcher.dispatch(OBJECT_MAPPER.readTree(rawRequest));
+    }
+
+    public static List<JsonRpcIncomingResponse> parseAndValidateStrictResponses(String rawPayload) {
+        JsonRpcResponseValidationOptions options = strictResponseOptions();
+        DefaultJsonRpcResponseParser parser = new DefaultJsonRpcResponseParser(options.rejectDuplicateMembers());
+        DefaultJsonRpcResponseValidator validator = new DefaultJsonRpcResponseValidator(options);
+
+        JsonRpcIncomingResponseEnvelope envelope = parser.parse(rawPayload);
+        List<JsonRpcIncomingResponse> responses = new ArrayList<>(envelope.responses().size());
+        for (JsonRpcIncomingResponse response : envelope.responses()) {
+            validator.validate(response);
+            responses.add(response);
+        }
+        return responses;
+    }
+}

--- a/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/ResponseSideUtilitiesExampleTest.java
+++ b/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/ResponseSideUtilitiesExampleTest.java
@@ -69,4 +69,30 @@ class ResponseSideUtilitiesExampleTest {
             {"jsonrpc":"2.0","id":1,"error":{"code":"bad","message":1}}
             """));
     }
+
+    @Test
+    void rejectsDuplicateMembersWhenConfigured() {
+        ResponseSideUtilitiesExample example = new ResponseSideUtilitiesExample(
+            JsonRpcResponseValidationOptions.builder()
+                .rejectDuplicateMembers(true)
+                .build()
+        );
+
+        assertThrows(JsonRpcException.class, () -> example.inspect("""
+            {"jsonrpc":"2.0","id":1,"id":2,"result":"pong"}
+            """));
+    }
+
+    @Test
+    void rejectsRequestFieldsInsideResponseWhenConfigured() {
+        ResponseSideUtilitiesExample example = new ResponseSideUtilitiesExample(
+            JsonRpcResponseValidationOptions.builder()
+                .rejectRequestFields(true)
+                .build()
+        );
+
+        assertThrows(JsonRpcException.class, () -> example.inspect("""
+            {"jsonrpc":"2.0","id":1,"result":"pong","method":"ping"}
+            """));
+    }
 }

--- a/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/ValidationProfileExampleTest.java
+++ b/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/ValidationProfileExampleTest.java
@@ -1,0 +1,68 @@
+package com.limehee.jsonrpc.sample.purejava;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.limehee.jsonrpc.core.JsonRpcDispatchResult;
+import com.limehee.jsonrpc.core.JsonRpcException;
+import com.limehee.jsonrpc.core.JsonRpcIncomingResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ValidationProfileExampleTest {
+
+    @Test
+    void strictRequestProfileRejectsNotificationWithoutId() throws Exception {
+        JsonRpcDispatchResult result = ValidationProfileExample.dispatchStrict("""
+            {"jsonrpc":"2.0","method":"ping"}
+            """);
+
+        assertTrue(result.hasResponse());
+        assertEquals(-32600, result.singleResponse().orElseThrow().error().code());
+        assertNull(result.singleResponse().orElseThrow().id());
+    }
+
+    @Test
+    void strictRequestProfileRejectsFractionalId() throws Exception {
+        JsonRpcDispatchResult result = ValidationProfileExample.dispatchStrict("""
+            {"jsonrpc":"2.0","method":"ping","id":1.5}
+            """);
+
+        assertEquals(-32600, result.singleResponse().orElseThrow().error().code());
+    }
+
+    @Test
+    void strictRequestProfileRejectsResponseFieldsInsideRequest() throws Exception {
+        JsonRpcDispatchResult result = ValidationProfileExample.dispatchStrict("""
+            {"jsonrpc":"2.0","method":"ping","id":1,"result":"unexpected"}
+            """);
+
+        assertEquals(-32600, result.singleResponse().orElseThrow().error().code());
+    }
+
+    @Test
+    void strictResponseProfileAcceptsStandardServerErrorRange() {
+        List<JsonRpcIncomingResponse> responses = ValidationProfileExample.parseAndValidateStrictResponses("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"server"}}
+            """);
+
+        assertEquals(1, responses.size());
+        assertEquals(-32000, responses.get(0).error().get("code").asInt());
+    }
+
+    @Test
+    void strictResponseProfileRejectsDuplicateMembers() {
+        assertThrows(JsonRpcException.class, () -> ValidationProfileExample.parseAndValidateStrictResponses("""
+            {"jsonrpc":"2.0","id":1,"id":2,"result":"pong"}
+            """));
+    }
+
+    @Test
+    void strictResponseProfileRejectsRequestFields() {
+        assertThrows(JsonRpcException.class, () -> ValidationProfileExample.parseAndValidateStrictResponses("""
+            {"jsonrpc":"2.0","id":1,"result":"pong","method":"ping"}
+            """));
+    }
+}

--- a/samples/spring-boot-demo/README.md
+++ b/samples/spring-boot-demo/README.md
@@ -10,6 +10,14 @@ From repository root:
 ./gradlew -p samples/spring-boot-demo bootRun
 ```
 
+## Run Tests
+
+From repository root:
+
+```bash
+./gradlew -p samples/spring-boot-demo test
+```
+
 Endpoint:
 
 - URL: `http://localhost:8080/jsonrpc`

--- a/samples/spring-boot-demo/README.md
+++ b/samples/spring-boot-demo/README.md
@@ -45,12 +45,24 @@ curl -s http://localhost:8080/jsonrpc \
   -d '{"jsonrpc":"2.0","method":"ping","id":1}'
 ```
 
+Expected response:
+
+```json
+{"jsonrpc":"2.0","id":1,"result":"pong"}
+```
+
 ### 2. Single-parameter DTO binding (`greet`)
 
 ```bash
 curl -s http://localhost:8080/jsonrpc \
   -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","method":"greet","params":{"name":"developer"},"id":2}'
+```
+
+Expected response:
+
+```json
+{"jsonrpc":"2.0","id":2,"result":"hello developer"}
 ```
 
 ### 3. Named params with `@JsonRpcParam` (`sum`)
@@ -61,12 +73,24 @@ curl -s http://localhost:8080/jsonrpc \
   -d '{"jsonrpc":"2.0","method":"sum","params":{"left":2,"right":3},"id":3}'
 ```
 
+Expected response:
+
+```json
+{"jsonrpc":"2.0","id":3,"result":5}
+```
+
 ### 4. Positional params (`sum`)
 
 ```bash
 curl -s http://localhost:8080/jsonrpc \
   -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","method":"sum","params":[2,3],"id":4}'
+```
+
+Expected response:
+
+```json
+{"jsonrpc":"2.0","id":4,"result":5}
 ```
 
 ### 5. Manual registration (`manual.echo`)
@@ -77,6 +101,12 @@ curl -s http://localhost:8080/jsonrpc \
   -d '{"jsonrpc":"2.0","method":"manual.echo","id":5}'
 ```
 
+Expected response:
+
+```json
+{"jsonrpc":"2.0","id":5,"result":"echo"}
+```
+
 ### 6. Typed registration (`typed.upper`, `typed.tags`)
 
 ```bash
@@ -85,10 +115,22 @@ curl -s http://localhost:8080/jsonrpc \
   -d '{"jsonrpc":"2.0","method":"typed.upper","params":{"value":"spring"},"id":6}'
 ```
 
+Expected response:
+
+```json
+{"jsonrpc":"2.0","id":6,"result":{"value":"SPRING"}}
+```
+
 ```bash
 curl -s http://localhost:8080/jsonrpc \
   -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","method":"typed.tags","id":7}'
+```
+
+Expected response:
+
+```json
+{"jsonrpc":"2.0","id":7,"result":["alpha","beta"]}
 ```
 
 ### 7. Notification (no response body)
@@ -98,6 +140,11 @@ curl -i -s http://localhost:8080/jsonrpc \
   -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","method":"ping"}'
 ```
+
+Expected response:
+
+- HTTP status: `204 No Content`
+- body: empty
 
 ### 8. Mixed batch (success + notification + error)
 
@@ -111,12 +158,27 @@ curl -s http://localhost:8080/jsonrpc \
       ]'
 ```
 
+Expected response:
+
+```json
+[
+  {"jsonrpc":"2.0","id":8,"result":"echo"},
+  {"jsonrpc":"2.0","id":9,"error":{"code":-32601,"message":"Method not found"}}
+]
+```
+
 ### 9. Parse error
 
 ```bash
 curl -s http://localhost:8080/jsonrpc \
   -H 'content-type: application/json' \
   -d '{'
+```
+
+Expected response:
+
+```json
+{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}
 ```
 
 ## Notification Executor Scenarios

--- a/samples/spring-boot-demo/README.md
+++ b/samples/spring-boot-demo/README.md
@@ -130,6 +130,31 @@ curl -s http://localhost:8080/jsonrpc \
 - Custom exception mapping path (`JsonRpcExceptionResolver` override) is covered by
   `GreetingRpcServiceCustomExceptionResolverIntegrationTest`.
 
+## Validation Profile Scenarios
+
+Spring sample also demonstrates request/response validation key symmetry through properties:
+
+```yaml
+jsonrpc:
+  validation:
+    request:
+      require-id-member: true
+      allow-fractional-id: false
+      reject-response-fields: true
+      reject-duplicate-members: true
+    response:
+      reject-request-fields: true
+      reject-duplicate-members: true
+      error-code:
+        policy: STANDARD_ONLY
+```
+
+Covered by `GreetingRpcServiceValidationProfilesIntegrationTest`:
+
+- request-side validation at the HTTP endpoint (`require-id-member`, fractional ID, polluted request fields, duplicate
+  members)
+- response-side parser/validator beans (`reject-duplicate-members`, `reject-request-fields`, `error-code.policy`)
+
 ## Test Coverage Entry Points
 
 - `src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceIntegrationTest.java`
@@ -140,3 +165,4 @@ curl -s http://localhost:8080/jsonrpc \
 - `src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceConflictPolicyIntegrationTest.java`
 - `src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceErrorDataExposureIntegrationTest.java`
 - `src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceCustomExceptionResolverIntegrationTest.java`
+- `src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceValidationProfilesIntegrationTest.java`

--- a/samples/spring-boot-demo/src/main/resources/application.yml
+++ b/samples/spring-boot-demo/src/main/resources/application.yml
@@ -4,3 +4,29 @@ server:
 jsonrpc:
   path: /jsonrpc
   include-error-data: false
+  validation:
+    request:
+      require-json-rpc-version-20: true
+      require-id-member: false
+      allow-null-id: true
+      allow-string-id: true
+      allow-numeric-id: true
+      allow-fractional-id: true
+      reject-response-fields: false
+      reject-duplicate-members: false
+      params-type-violation-code-policy: INVALID_PARAMS
+    response:
+      require-json-rpc-version-20: true
+      require-id-member: true
+      allow-null-id: true
+      allow-string-id: true
+      allow-numeric-id: true
+      allow-fractional-id: true
+      require-exclusive-result-or-error: true
+      require-error-object-when-present: true
+      require-integer-error-code: true
+      require-string-error-message: true
+      reject-request-fields: false
+      reject-duplicate-members: false
+      error-code:
+        policy: ANY_INTEGER

--- a/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceValidationProfilesIntegrationTest.java
+++ b/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceValidationProfilesIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.limehee.jsonrpc.sample;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.limehee.jsonrpc.core.DefaultJsonRpcResponseParser;
+import com.limehee.jsonrpc.core.JsonRpcException;
+import com.limehee.jsonrpc.core.JsonRpcIncomingResponse;
+import com.limehee.jsonrpc.core.JsonRpcResponseValidator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import tools.jackson.databind.JsonNode;
+
+@SpringBootTest(properties = {
+    "jsonrpc.validation.request.require-id-member=true",
+    "jsonrpc.validation.request.allow-fractional-id=false",
+    "jsonrpc.validation.request.reject-response-fields=true",
+    "jsonrpc.validation.request.reject-duplicate-members=true",
+    "jsonrpc.validation.response.reject-duplicate-members=true",
+    "jsonrpc.validation.response.reject-request-fields=true",
+    "jsonrpc.validation.response.error-code.policy=STANDARD_ONLY"
+})
+class GreetingRpcServiceValidationProfilesIntegrationTest extends AbstractJsonRpcIntegrationSupport {
+
+    @Autowired
+    private DefaultJsonRpcResponseParser responseParser;
+
+    @Autowired
+    private JsonRpcResponseValidator responseValidator;
+
+    @Test
+    void rejectsNotificationWithoutIdWhenRequireIdMemberEnabled() throws Exception {
+        JsonNode body = invokeJsonRpc("""
+            {"jsonrpc":"2.0","method":"ping"}
+            """);
+
+        assertEquals(-32600, body.get("error").get("code").asInt());
+    }
+
+    @Test
+    void rejectsResponseFieldsInsideRequestWhenConfigured() throws Exception {
+        JsonNode body = invokeJsonRpc("""
+            {"jsonrpc":"2.0","method":"ping","id":1,"result":"unexpected"}
+            """);
+
+        assertEquals(-32600, body.get("error").get("code").asInt());
+    }
+
+    @Test
+    void rejectsFractionalRequestIdWhenConfigured() throws Exception {
+        JsonNode body = invokeJsonRpc("""
+            {"jsonrpc":"2.0","method":"ping","id":1.5}
+            """);
+
+        assertEquals(-32600, body.get("error").get("code").asInt());
+    }
+
+    @Test
+    void rejectsDuplicateRequestMembersWhenConfigured() throws Exception {
+        JsonNode body = invokeJsonRpc("""
+            {"jsonrpc":"2.0","method":"ping","id":1,"id":2}
+            """);
+
+        assertEquals(-32700, body.get("error").get("code").asInt());
+    }
+
+    @Test
+    void responseParserRejectsDuplicateMembersWhenConfigured() {
+        assertThrows(JsonRpcException.class, () -> responseParser.parse("""
+            {"jsonrpc":"2.0","id":1,"id":2,"result":"pong"}
+            """));
+    }
+
+    @Test
+    void responseValidatorAppliesStandardOnlyErrorCodePolicy() {
+        JsonRpcIncomingResponse standardError = responseParser.parse("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"internal"}}
+            """).singleResponse().orElseThrow();
+        JsonRpcIncomingResponse serverRangeError = responseParser.parse("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"server"}}
+            """).singleResponse().orElseThrow();
+
+        responseValidator.validate(standardError);
+        assertThrows(JsonRpcException.class, () -> responseValidator.validate(serverRangeError));
+    }
+
+    @Test
+    void responseValidatorRejectsRequestFieldsWhenConfigured() {
+        JsonRpcIncomingResponse pollutedResponse = responseParser.parse("""
+            {"jsonrpc":"2.0","id":1,"result":"ok","method":"ping"}
+            """).singleResponse().orElseThrow();
+
+        assertThrows(JsonRpcException.class, () -> responseValidator.validate(pollutedResponse));
+    }
+}


### PR DESCRIPTION
## Summary

This PR completes the validation/options overhaul for JSON-RPC request/response handling and aligns Spring auto-configuration with core behavior.

Key updates:
- Added symmetric request/response validation options in `jsonrpc-core` (ID rules, duplicate-member policies, field rejection policies).
- Added strict duplicate-member parsing support via shared payload reader and wired it through core/webmvc/autoconfigure.
- Exposed and bound response parser/validator options in Spring Boot auto-configuration.
- Fixed autoconfigure precedence so custom `JsonRpcRequestValidationOptions` / `JsonRpcResponseValidationOptions` beans are honored consistently.
- Added hard fail-fast constraints for invalid constructor/property inputs (including positive-only metric method-tag cap).
- Enforced hard cap semantics for metric method-tag cardinality under concurrency.
- Expanded tests across core/autoconfigure/webmvc/samples for success/failure/branch/concurrency paths.
- Updated docs and metadata (configuration reference, migration mapping, sample guides, expected JSON outputs).

## Related Issues

- Closes #20
- Related #

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [x] Test
- [x] Build/CI

## JSON-RPC Impact

Describe protocol-level impact, if any:

- [ ] No protocol behavior change
- [x] Request validation behavior changed
- [ ] Error mapping behavior changed
- [ ] Method registration/dispatch behavior changed

Details:
- Validation behavior is now more explicitly controlled through symmetric request/response options.
- Duplicate-member rejection can be enforced consistently for request/response raw parsing paths.
- Reserved method namespace (`rpc.*`) rejection and stricter fail-fast constraints are enforced where configured.
- Default behavior remains RFC-oriented and documented; strict toggles are opt-in via configuration.

## Validation

- [x] `./gradlew test`
- [x] `./gradlew check`
- [x] Added/updated tests for new behavior

## Documentation

- [x] Updated README (if needed)
- [x] Added migration notes for breaking changes (if any)
