### PR TITLE
feat(core): add outbound request builders and runnable composition samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,18 @@ Detailed docs are under [`docs/`](docs/):
 ## Sample
 
 - Spring Boot sample app: [`samples/spring-boot-demo`](samples/spring-boot-demo)
+- Spring Boot sample guide: [`samples/spring-boot-demo/README.md`](samples/spring-boot-demo/README.md)
+- Spring Boot annotation/manual/typed server examples:
+  - [`samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/GreetingRpcService.java`](samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/GreetingRpcService.java)
+  - [`samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/SampleRegistrationConfig.java`](samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/SampleRegistrationConfig.java)
+- Spring Boot outbound client-side composition example:
+  - [`samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java`](samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java)
 - Pure Java sample app: [`samples/pure-java-demo`](samples/pure-java-demo)
+- Pure Java sample guide: [`samples/pure-java-demo/README.md`](samples/pure-java-demo/README.md)
+- Pure Java dispatcher example:
+  - [`samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java`](samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java)
+- Pure Java outbound client-side composition example:
+  - [`samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java`](samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java)
 
 Run:
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,15 @@ ObjectNode singleRequest = JsonRpcRequestBuilder.request("inventory.lookup")
     })
     .buildNode();
 
+ObjectNode positionalRequest = JsonRpcRequestBuilder.request("inventory.reserve")
+    .id(10L)
+    .paramsArray(
+        JsonNodeFactory.instance.stringNode("book-001"),
+        JsonNodeFactory.instance.numberNode(2),
+        JsonNodeFactory.instance.booleanNode(true)
+    )
+    .buildNode();
+
 ArrayNode batchRequest = new JsonRpcRequestBatchBuilder()
     .add(JsonRpcRequestBuilder.request("inventory.lookup").id(1L))
     .addNotification("audit.record", request -> request.paramsObject(params -> {

--- a/README.md
+++ b/README.md
@@ -221,6 +221,41 @@ JsonRpcDispatchResult result = dispatcher.dispatch(payload);
 System.out.println(mapper.writeValueAsString(result.singleResponse().orElseThrow()));
 ```
 
+## Outbound Request Composition
+
+Use `JsonRpcRequestBuilder` and `JsonRpcRequestBatchBuilder` when your application needs to send JSON-RPC payloads to
+another endpoint.
+
+```java
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import com.limehee.jsonrpc.core.JsonRpcRequestBatchBuilder;
+import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+
+ObjectNode singleRequest = JsonRpcRequestBuilder.request("inventory.lookup")
+    .id("req-7")
+    .paramsObject(params -> {
+        params.put("sku", "book-001");
+        params.put("warehouse", "seoul");
+    })
+    .buildNode();
+
+ArrayNode batchRequest = new JsonRpcRequestBatchBuilder()
+    .add(JsonRpcRequestBuilder.request("inventory.lookup").id(1L))
+    .addNotification("audit.record", request -> request.paramsObject(params -> {
+        params.put("event", "inventory.lookup");
+        params.put("source", "gateway");
+    }))
+    .buildNode();
+```
+
+Builder contract:
+
+- `request(...)` must define an `id` before `buildNode()`
+- `notification(...)` rejects any `id(...)` or `nullId()` call
+- `params(...)`, `paramsArray(...)`, and `paramsObject(...)` are mutually exclusive and can be configured only once
+- `JsonRpcRequestBatchBuilder` rejects empty batches at `buildNode()`
+
 ## Registration Styles and Priority
 
 Supported styles:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,7 +182,26 @@ JsonRpcDispatchResult result = dispatcher.dispatch(request);
 System.out.println(mapper.writeValueAsString(result.singleResponse().orElseThrow()));
 ```
 
-## 6. Verify with cURL
+## 6. Outbound Request Composition
+
+Use request builders when the same application also needs to call another JSON-RPC service.
+
+```java
+import tools.jackson.databind.node.ObjectNode;
+import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+
+ObjectNode request = JsonRpcRequestBuilder.request("inventory.lookup")
+    .id("req-7")
+    .paramsObject(params -> {
+        params.put("sku", "book-001");
+        params.put("warehouse", "seoul");
+    })
+    .buildNode();
+```
+
+See [`pure-java-guide.md`](pure-java-guide.md) for batch examples and the full builder contract.
+
+## 7. Verify with cURL
 
 ```bash
 curl -sS -X POST http://localhost:8080/jsonrpc \
@@ -190,7 +209,7 @@ curl -sS -X POST http://localhost:8080/jsonrpc \
   -d '{"jsonrpc":"2.0","method":"greet","params":{"name":"rpc"},"id":1}'
 ```
 
-## 7. What to Read Next
+## 8. What to Read Next
 
 - Full Spring setup, registration styles, and operational options: [`spring-boot-guide.md`](spring-boot-guide.md)
 - Pure Java advanced composition and custom transport patterns: [`pure-java-guide.md`](pure-java-guide.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,13 +150,24 @@ Default endpoint:
 Request:
 
 ```json
-{"jsonrpc":"2.0","method":"greet","params":{"name":"developer"},"id":1}
+{
+  "jsonrpc": "2.0",
+  "method": "greet",
+  "params": {
+    "name": "developer"
+  },
+  "id": 1
+}
 ```
 
 Response:
 
 ```json
-{"jsonrpc":"2.0","id":1,"result":"hello developer"}
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "hello developer"
+}
 ```
 
 ## 5. Pure Java Minimal Example

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -209,7 +209,16 @@ curl -sS -X POST http://localhost:8080/jsonrpc \
   -d '{"jsonrpc":"2.0","method":"greet","params":{"name":"rpc"},"id":1}'
 ```
 
-## 8. What to Read Next
+## 8. Runnable Samples
+
+- Spring Boot sample guide: [`../samples/spring-boot-demo/README.md`](../samples/spring-boot-demo/README.md)
+- Spring Boot server example: [`../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/GreetingRpcService.java`](../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/GreetingRpcService.java)
+- Spring Boot outbound composition example: [`../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java`](../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java)
+- Pure Java sample guide: [`../samples/pure-java-demo/README.md`](../samples/pure-java-demo/README.md)
+- Pure Java dispatcher example: [`../samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java`](../samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java)
+- Pure Java outbound composition example: [`../samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java`](../samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java)
+
+## 9. What to Read Next
 
 - Full Spring setup, registration styles, and operational options: [`spring-boot-guide.md`](spring-boot-guide.md)
 - Pure Java advanced composition and custom transport patterns: [`pure-java-guide.md`](pure-java-guide.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -188,6 +188,7 @@ Use request builders when the same application also needs to call another JSON-R
 
 ```java
 import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.JsonNodeFactory;
 import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
 
 ObjectNode request = JsonRpcRequestBuilder.request("inventory.lookup")
@@ -196,6 +197,15 @@ ObjectNode request = JsonRpcRequestBuilder.request("inventory.lookup")
         params.put("sku", "book-001");
         params.put("warehouse", "seoul");
     })
+    .buildNode();
+
+ObjectNode positionalRequest = JsonRpcRequestBuilder.request("inventory.reserve")
+    .id(10L)
+    .paramsArray(
+        JsonNodeFactory.instance.stringNode("book-001"),
+        JsonNodeFactory.instance.numberNode(2),
+        JsonNodeFactory.instance.booleanNode(true)
+    )
     .buildNode();
 ```
 

--- a/docs/pure-java-guide.md
+++ b/docs/pure-java-guide.md
@@ -339,13 +339,13 @@ if (envelopeType == JsonRpcEnvelopeType.REQUEST) {
 For policy tuning, customize `JsonRpcResponseValidationOptions` and pass it into
 `DefaultJsonRpcResponseValidator`.
 
-## 9. Concurrency Notes
+## 10. Concurrency Notes
 
 - `JsonRpcDispatcher` invocation path is stateless per request except method registry lookups.
 - Notification behavior depends on the configured `JsonRpcNotificationExecutor`.
 - For asynchronous notification isolation in plain Java, provide an executor-backed implementation.
 
-## 10. Deep References
+## 11. Deep References
 
 - Protocol matrix: [`protocol-and-compliance.md`](protocol-and-compliance.md)
 - Registration/binding semantics: [`registration-and-binding.md`](registration-and-binding.md)

--- a/docs/pure-java-guide.md
+++ b/docs/pure-java-guide.md
@@ -81,7 +81,65 @@ String json = mapper.writeValueAsString(result.singleResponse().orElseThrow());
 System.out.println(json);
 ```
 
-## 3. Typed Registration (`JsonRpcTypedMethodHandlerFactory`)
+## 3. Compose Outbound Request Payloads
+
+Use the request builders when your code acts as a JSON-RPC client and needs to send transport-ready payloads to
+another service.
+
+### 3.1 Single request
+
+```java
+import tools.jackson.databind.node.ObjectNode;
+import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+
+ObjectNode request = JsonRpcRequestBuilder.request("inventory.lookup")
+        .id("req-7")
+        .paramsObject(params -> {
+            params.put("sku", "book-001");
+            params.put("warehouse", "seoul");
+        })
+        .buildNode();
+```
+
+### 3.2 Notification
+
+```java
+import tools.jackson.databind.node.ObjectNode;
+import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+
+ObjectNode notification = JsonRpcRequestBuilder.notification("audit.record")
+        .paramsObject(params -> {
+            params.put("event", "inventory.lookup");
+            params.put("source", "gateway");
+        })
+        .buildNode();
+```
+
+### 3.3 Batch request
+
+```java
+import tools.jackson.databind.node.ArrayNode;
+import com.limehee.jsonrpc.core.JsonRpcRequestBatchBuilder;
+import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+
+ArrayNode batch = new JsonRpcRequestBatchBuilder()
+        .add(JsonRpcRequestBuilder.request("inventory.lookup").id(1L))
+        .addNotification("audit.record", request -> request.paramsObject(params -> {
+            params.put("event", "inventory.lookup");
+            params.put("source", "gateway");
+        }))
+        .buildNode();
+```
+
+### 3.4 Fail-fast API contract
+
+- `request(...)` must define an `id` before `buildNode()`
+- `notification(...)` rejects `id(...)` and `nullId()`
+- `params(...)`, `paramsArray(...)`, and `paramsObject(...)` are mutually exclusive and may be called only once per builder
+- `params(JsonNode)` accepts only object or array nodes
+- `JsonRpcRequestBatchBuilder` rejects empty batches
+
+## 4. Typed Registration (`JsonRpcTypedMethodHandlerFactory`)
 
 ```java
 import tools.jackson.databind.ObjectMapper;
@@ -110,16 +168,16 @@ dispatcher.register(
 );
 ```
 
-## 4. DTO Shapes: Record, Class, Collection, Map
+## 5. DTO Shapes: Record, Class, Collection, Map
 
-### 4.1 Record input/output
+### 5.1 Record input/output
 
 ```java
 record UserQuery(long id) {}
 record UserView(long id, String name) {}
 ```
 
-### 4.2 POJO input
+### 5.2 POJO input
 
 ```java
 class CreateTagRequest {
@@ -127,7 +185,7 @@ class CreateTagRequest {
 }
 ```
 
-### 4.3 Collection return
+### 5.3 Collection return
 
 ```java
 dispatcher.register(
@@ -136,7 +194,7 @@ dispatcher.register(
 );
 ```
 
-### 4.4 Map return
+### 5.4 Map return
 
 ```java
 dispatcher.register(
@@ -147,9 +205,9 @@ dispatcher.register(
 
 All mapping is Jackson-based via binder/result-writer components.
 
-## 5. Batch, Notification, and Error Cases
+## 6. Batch, Notification, and Error Cases
 
-### 5.1 Batch request
+### 6.1 Batch request
 
 ```json
 [
@@ -165,18 +223,32 @@ Behavior:
 - unknown method becomes `-32601`
 - response array contains only non-notification entries in traversal order
 
-### 5.2 Empty batch
+### 6.2 Empty batch
 
 `[]` returns one `-32600 Invalid Request` error object.
 
-### 5.3 Parse/validation/runtime errors
+### 6.3 Parse/validation/runtime errors
 
 - invalid JSON text -> `-32700`
 - invalid request shape -> `-32600`
 - parameter mapping failure -> `-32602`
 - unhandled runtime exception -> `-32603`
 
-## 6. Compose Custom Dispatcher Pipeline
+### 6.4 Manual error objects with data
+
+```java
+import com.limehee.jsonrpc.core.JsonRpcError;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+
+ObjectNode errorData = JsonNodeFactory.instance.objectNode()
+        .put("traceId", "trace-123")
+        .put("service", "inventory-gateway");
+
+JsonRpcError error = JsonRpcError.of(-32001, "Inventory upstream failed", errorData);
+```
+
+## 7. Compose Custom Dispatcher Pipeline
 
 You can inject your own implementations for parser/validator/invoker/etc.
 
@@ -215,7 +287,7 @@ an object/array:
 - `INVALID_PARAMS` (default behavior): `-32602`
 - `INVALID_REQUEST`: `-32600`
 
-## 7. Custom Transport Pattern
+## 8. Custom Transport Pattern
 
 When using Netty, Undertow, Vert.x, CLI stdin/stdout, message queues, or any custom transport, use this pattern:
 
@@ -225,7 +297,7 @@ When using Netty, Undertow, Vert.x, CLI stdin/stdout, message queues, or any cus
 4. If `hasResponse()` is false, do not emit body.
 5. If response exists, serialize single response or response list to JSON.
 
-## 8. Incoming Response Pattern (Bidirectional Transport)
+## 9. Incoming Response Pattern (Bidirectional Transport)
 
 Use response-side protocol utilities when the same channel receives both requests and responses.
 

--- a/docs/pure-java-guide.md
+++ b/docs/pure-java-guide.md
@@ -73,8 +73,8 @@ JsonRpcDispatcher dispatcher = new JsonRpcDispatcher();
 dispatcher.register("ping", params -> StringNode.valueOf("pong"));
 
 JsonNode request = mapper.readTree("""
-{"jsonrpc":"2.0","method":"ping","id":1}
-""");
+    {"jsonrpc":"2.0","method":"ping","id":1}
+    """);
 
 JsonRpcDispatchResult result = dispatcher.dispatch(request);
 String json = mapper.writeValueAsString(result.singleResponse().orElseThrow());
@@ -93,12 +93,12 @@ import tools.jackson.databind.node.ObjectNode;
 import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
 
 ObjectNode request = JsonRpcRequestBuilder.request("inventory.lookup")
-        .id("req-7")
-        .paramsObject(params -> {
-            params.put("sku", "book-001");
-            params.put("warehouse", "seoul");
-        })
-        .buildNode();
+    .id("req-7")
+    .paramsObject(params -> {
+        params.put("sku", "book-001");
+        params.put("warehouse", "seoul");
+    })
+    .buildNode();
 ```
 
 ### 3.2 Positional params with `paramsArray(...)`
@@ -109,13 +109,13 @@ import tools.jackson.databind.node.JsonNodeFactory;
 import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
 
 ObjectNode request = JsonRpcRequestBuilder.request("inventory.reserve")
-        .id(10L)
-        .paramsArray(
-            JsonNodeFactory.instance.stringNode("book-001"),
-            JsonNodeFactory.instance.numberNode(2),
-            JsonNodeFactory.instance.booleanNode(true)
-        )
-        .buildNode();
+    .id(10L)
+    .paramsArray(
+        JsonNodeFactory.instance.stringNode("book-001"),
+        JsonNodeFactory.instance.numberNode(2),
+        JsonNodeFactory.instance.booleanNode(true)
+    )
+    .buildNode();
 ```
 
 ### 3.3 Notification
@@ -125,11 +125,11 @@ import tools.jackson.databind.node.ObjectNode;
 import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
 
 ObjectNode notification = JsonRpcRequestBuilder.notification("audit.record")
-        .paramsObject(params -> {
-            params.put("event", "inventory.lookup");
-            params.put("source", "gateway");
-        })
-        .buildNode();
+    .paramsObject(params -> {
+        params.put("event", "inventory.lookup");
+        params.put("source", "gateway");
+    })
+    .buildNode();
 ```
 
 ### 3.4 Batch request
@@ -140,12 +140,12 @@ import com.limehee.jsonrpc.core.JsonRpcRequestBatchBuilder;
 import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
 
 ArrayNode batch = new JsonRpcRequestBatchBuilder()
-        .add(JsonRpcRequestBuilder.request("inventory.lookup").id(1L))
-        .addNotification("audit.record", request -> request.paramsObject(params -> {
-            params.put("event", "inventory.lookup");
-            params.put("source", "gateway");
-        }))
-        .buildNode();
+    .add(JsonRpcRequestBuilder.request("inventory.lookup").id(1L))
+    .addNotification("audit.record", request -> request.paramsObject(params -> {
+        params.put("event", "inventory.lookup");
+        params.put("source", "gateway");
+    }))
+    .buildNode();
 ```
 
 ### 3.5 Fail-fast API contract
@@ -173,13 +173,18 @@ import com.limehee.jsonrpc.core.JsonRpcDispatcher;
 import com.limehee.jsonrpc.core.JsonRpcMethodRegistration;
 import com.limehee.jsonrpc.core.JsonRpcTypedMethodHandlerFactory;
 
-record UpperIn(String value) {}
-record UpperOut(String value) {}
+record UpperIn(String value) {
+
+}
+
+record UpperOut(String value) {
+
+}
 
 ObjectMapper mapper = JsonMapper.builder().build();
 JsonRpcTypedMethodHandlerFactory factory = new DefaultJsonRpcTypedMethodHandlerFactory(
-        new JacksonJsonRpcParameterBinder(mapper),
-        new JacksonJsonRpcResultWriter(mapper)
+    new JacksonJsonRpcParameterBinder(mapper),
+    new JacksonJsonRpcResultWriter(mapper)
 );
 
 JsonRpcDispatcher dispatcher = new JsonRpcDispatcher();
@@ -195,14 +200,20 @@ dispatcher.register(
 ### 5.1 Record input/output
 
 ```java
-record UserQuery(long id) {}
-record UserView(long id, String name) {}
+record UserQuery(long id) {
+
+}
+
+record UserView(long id, String name) {
+
+}
 ```
 
 ### 5.2 POJO input
 
 ```java
 class CreateTagRequest {
+
     public String name;
 }
 ```
@@ -233,9 +244,20 @@ All mapping is Jackson-based via binder/result-writer components.
 
 ```json
 [
-  {"jsonrpc":"2.0","method":"ping","id":1},
-  {"jsonrpc":"2.0","method":"ping"},
-  {"jsonrpc":"2.0","method":"unknown","id":2}
+  {
+    "jsonrpc": "2.0",
+    "method": "ping",
+    "id": 1
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "ping"
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "unknown",
+    "id": 2
+  }
 ]
 ```
 
@@ -264,8 +286,8 @@ import tools.jackson.databind.node.JsonNodeFactory;
 import tools.jackson.databind.node.ObjectNode;
 
 ObjectNode errorData = JsonNodeFactory.instance.objectNode()
-        .put("traceId", "trace-123")
-        .put("service", "inventory-gateway");
+    .put("traceId", "trace-123")
+    .put("service", "inventory-gateway");
 
 JsonRpcError error = JsonRpcError.of(-32001, "Inventory upstream failed", errorData);
 ```
@@ -288,15 +310,15 @@ import com.limehee.jsonrpc.core.JsonRpcMethodRegistrationConflictPolicy;
 import java.util.List;
 
 JsonRpcDispatcher dispatcher = new JsonRpcDispatcher(
-        new InMemoryJsonRpcMethodRegistry(JsonRpcMethodRegistrationConflictPolicy.REJECT),
-        new DefaultJsonRpcRequestParser(),
-        new DefaultJsonRpcRequestValidator(JsonRpcParamsTypeViolationCodePolicy.INVALID_PARAMS),
-        new DefaultJsonRpcMethodInvoker(),
-        new DefaultJsonRpcExceptionResolver(false),
-        new DefaultJsonRpcResponseComposer(),
-        100,
-        List.of(),
-        new DirectJsonRpcNotificationExecutor()
+    new InMemoryJsonRpcMethodRegistry(JsonRpcMethodRegistrationConflictPolicy.REJECT),
+    new DefaultJsonRpcRequestParser(),
+    new DefaultJsonRpcRequestValidator(JsonRpcParamsTypeViolationCodePolicy.INVALID_PARAMS),
+    new DefaultJsonRpcMethodInvoker(),
+    new DefaultJsonRpcExceptionResolver(false),
+    new DefaultJsonRpcResponseComposer(),
+    100,
+    List.of(),
+    new DirectJsonRpcNotificationExecutor()
 );
 ```
 

--- a/docs/pure-java-guide.md
+++ b/docs/pure-java-guide.md
@@ -101,7 +101,24 @@ ObjectNode request = JsonRpcRequestBuilder.request("inventory.lookup")
         .buildNode();
 ```
 
-### 3.2 Notification
+### 3.2 Positional params with `paramsArray(...)`
+
+```java
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+
+ObjectNode request = JsonRpcRequestBuilder.request("inventory.reserve")
+        .id(10L)
+        .paramsArray(
+            JsonNodeFactory.instance.stringNode("book-001"),
+            JsonNodeFactory.instance.numberNode(2),
+            JsonNodeFactory.instance.booleanNode(true)
+        )
+        .buildNode();
+```
+
+### 3.3 Notification
 
 ```java
 import tools.jackson.databind.node.ObjectNode;
@@ -115,7 +132,7 @@ ObjectNode notification = JsonRpcRequestBuilder.notification("audit.record")
         .buildNode();
 ```
 
-### 3.3 Batch request
+### 3.4 Batch request
 
 ```java
 import tools.jackson.databind.node.ArrayNode;
@@ -131,7 +148,7 @@ ArrayNode batch = new JsonRpcRequestBatchBuilder()
         .buildNode();
 ```
 
-### 3.4 Fail-fast API contract
+### 3.5 Fail-fast API contract
 
 - `request(...)` must define an `id` before `buildNode()`
 - `notification(...)` rejects `id(...)` and `nullId()`

--- a/docs/pure-java-guide.md
+++ b/docs/pure-java-guide.md
@@ -139,6 +139,11 @@ ArrayNode batch = new JsonRpcRequestBatchBuilder()
 - `params(JsonNode)` accepts only object or array nodes
 - `JsonRpcRequestBatchBuilder` rejects empty batches
 
+Runnable sample code:
+
+- [`../samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java`](../samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java)
+- [`../samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java`](../samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java)
+
 ## 4. Typed Registration (`JsonRpcTypedMethodHandlerFactory`)
 
 ```java

--- a/docs/spring-boot-guide.md
+++ b/docs/spring-boot-guide.md
@@ -154,6 +154,12 @@ class TypedRpcConfig {
 
 Use this when you want compile-time DTO types and reuse the standard binder/writer pipeline.
 
+Runnable sample code:
+
+- [`../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/GreetingRpcService.java`](../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/GreetingRpcService.java)
+- [`../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/SampleRegistrationConfig.java`](../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/SampleRegistrationConfig.java)
+- [`../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java`](../samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java)
+
 ## 4. Registration Priority and Conflict Policy
 
 Two registration phases exist in auto-configuration:

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcError.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcError.java
@@ -24,4 +24,16 @@ public record JsonRpcError(int code, String message, @Nullable JsonNode data) {
     public static JsonRpcError of(int code, String message) {
         return new JsonRpcError(code, message, null);
     }
+
+    /**
+     * Creates an error object with an explicit data payload.
+     *
+     * @param code    JSON-RPC error code
+     * @param message human-readable error message
+     * @param data    optional error data payload; may be {@code null}
+     * @return error object
+     */
+    public static JsonRpcError of(int code, String message, @Nullable JsonNode data) {
+        return new JsonRpcError(code, message, data);
+    }
 }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequest.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequest.java
@@ -5,6 +5,11 @@ import tools.jackson.databind.JsonNode;
 
 /**
  * Parsed JSON-RPC request model used by the dispatcher pipeline.
+ * <p>
+ * This type is primarily produced by {@link DefaultJsonRpcRequestParser} and consumed internally by validation,
+ * interception, and dispatch components. For outbound JSON-RPC request composition, prefer
+ * {@link JsonRpcRequestBuilder}.
+ * </p>
  *
  * @param jsonrpc   protocol version string from payload; may be {@code null}
  * @param id        request id value; may be {@code null}

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilder.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilder.java
@@ -34,7 +34,7 @@ public final class JsonRpcRequestBatchBuilder {
      * @param method JSON-RPC method name
      * @param customizer callback used to configure the request builder
      * @return this builder
-     * @throws NullPointerException if {@code customizer} is {@code null}
+     * @throws NullPointerException if {@code method} or {@code customizer} is {@code null}
      * @throws IllegalArgumentException if {@code method} is invalid
      */
     public JsonRpcRequestBatchBuilder addRequest(String method, Consumer<JsonRpcRequestBuilder> customizer) {
@@ -50,7 +50,7 @@ public final class JsonRpcRequestBatchBuilder {
      * @param method JSON-RPC method name
      * @param customizer callback used to configure the notification builder
      * @return this builder
-     * @throws NullPointerException if {@code customizer} is {@code null}
+     * @throws NullPointerException if {@code method} or {@code customizer} is {@code null}
      * @throws IllegalArgumentException if {@code method} is invalid
      */
     public JsonRpcRequestBatchBuilder addNotification(String method, Consumer<JsonRpcRequestBuilder> customizer) {
@@ -64,7 +64,8 @@ public final class JsonRpcRequestBatchBuilder {
      * Builds a batch payload.
      *
      * @return transport-ready JSON array node
-     * @throws IllegalStateException if no batch entries have been added
+     * @throws IllegalStateException if no batch entries have been added or if an included request builder is in an
+     * invalid state when the batch is materialized
      */
     public ArrayNode buildNode() {
         if (requests.isEmpty()) {

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilder.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilder.java
@@ -1,0 +1,80 @@
+package com.limehee.jsonrpc.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Builder for composing outbound JSON-RPC batch request payloads.
+ */
+public final class JsonRpcRequestBatchBuilder {
+
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+
+    private final List<JsonRpcRequestBuilder> requests = new ArrayList<>();
+
+    /**
+     * Adds a preconfigured request or notification builder to the batch.
+     *
+     * @param builder request builder to add
+     * @return this builder
+     * @throws NullPointerException if {@code builder} is {@code null}
+     */
+    public JsonRpcRequestBatchBuilder add(JsonRpcRequestBuilder builder) {
+        requests.add(Objects.requireNonNull(builder, "builder"));
+        return this;
+    }
+
+    /**
+     * Creates, customizes, and adds a request builder.
+     *
+     * @param method JSON-RPC method name
+     * @param customizer callback used to configure the request builder
+     * @return this builder
+     * @throws NullPointerException if {@code customizer} is {@code null}
+     * @throws IllegalArgumentException if {@code method} is invalid
+     */
+    public JsonRpcRequestBatchBuilder addRequest(String method, Consumer<JsonRpcRequestBuilder> customizer) {
+        Objects.requireNonNull(customizer, "customizer");
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.request(method);
+        customizer.accept(builder);
+        return add(builder);
+    }
+
+    /**
+     * Creates, customizes, and adds a notification builder.
+     *
+     * @param method JSON-RPC method name
+     * @param customizer callback used to configure the notification builder
+     * @return this builder
+     * @throws NullPointerException if {@code customizer} is {@code null}
+     * @throws IllegalArgumentException if {@code method} is invalid
+     */
+    public JsonRpcRequestBatchBuilder addNotification(String method, Consumer<JsonRpcRequestBuilder> customizer) {
+        Objects.requireNonNull(customizer, "customizer");
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.notification(method);
+        customizer.accept(builder);
+        return add(builder);
+    }
+
+    /**
+     * Builds a batch payload.
+     *
+     * @return transport-ready JSON array node
+     * @throws IllegalStateException if no batch entries have been added
+     */
+    public ArrayNode buildNode() {
+        if (requests.isEmpty()) {
+            throw new IllegalStateException("Batch requests must contain at least one entry");
+        }
+
+        ArrayNode arrayNode = NODE_FACTORY.arrayNode();
+        for (JsonRpcRequestBuilder request : requests) {
+            arrayNode.add(request.buildNode());
+        }
+        return arrayNode;
+    }
+}

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilder.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilder.java
@@ -31,10 +31,10 @@ public final class JsonRpcRequestBatchBuilder {
     /**
      * Creates, customizes, and adds a request builder.
      *
-     * @param method JSON-RPC method name
+     * @param method     JSON-RPC method name
      * @param customizer callback used to configure the request builder
      * @return this builder
-     * @throws NullPointerException if {@code method} or {@code customizer} is {@code null}
+     * @throws NullPointerException     if {@code method} or {@code customizer} is {@code null}
      * @throws IllegalArgumentException if {@code method} is invalid
      */
     public JsonRpcRequestBatchBuilder addRequest(String method, Consumer<JsonRpcRequestBuilder> customizer) {
@@ -47,10 +47,10 @@ public final class JsonRpcRequestBatchBuilder {
     /**
      * Creates, customizes, and adds a notification builder.
      *
-     * @param method JSON-RPC method name
+     * @param method     JSON-RPC method name
      * @param customizer callback used to configure the notification builder
      * @return this builder
-     * @throws NullPointerException if {@code method} or {@code customizer} is {@code null}
+     * @throws NullPointerException     if {@code method} or {@code customizer} is {@code null}
      * @throws IllegalArgumentException if {@code method} is invalid
      */
     public JsonRpcRequestBatchBuilder addNotification(String method, Consumer<JsonRpcRequestBuilder> customizer) {
@@ -65,7 +65,7 @@ public final class JsonRpcRequestBatchBuilder {
      *
      * @return transport-ready JSON array node
      * @throws IllegalStateException if no batch entries have been added or if an included request builder is in an
-     * invalid state when the batch is materialized
+     *                               invalid state when the batch is materialized
      */
     public ArrayNode buildNode() {
         if (requests.isEmpty()) {

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
@@ -37,6 +37,7 @@ public final class JsonRpcRequestBuilder {
      *
      * @param method JSON-RPC method name
      * @return request builder
+     * @throws NullPointerException if {@code method} is {@code null}
      * @throws IllegalArgumentException if {@code method} is blank or uses the reserved {@code rpc.*} namespace
      */
     public static JsonRpcRequestBuilder request(String method) {
@@ -48,6 +49,7 @@ public final class JsonRpcRequestBuilder {
      *
      * @param method JSON-RPC method name
      * @return notification builder
+     * @throws NullPointerException if {@code method} is {@code null}
      * @throws IllegalArgumentException if {@code method} is blank or uses the reserved {@code rpc.*} namespace
      */
     public static JsonRpcRequestBuilder notification(String method) {

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
@@ -37,7 +37,7 @@ public final class JsonRpcRequestBuilder {
      *
      * @param method JSON-RPC method name
      * @return request builder
-     * @throws NullPointerException if {@code method} is {@code null}
+     * @throws NullPointerException     if {@code method} is {@code null}
      * @throws IllegalArgumentException if {@code method} is blank or uses the reserved {@code rpc.*} namespace
      */
     public static JsonRpcRequestBuilder request(String method) {
@@ -49,11 +49,51 @@ public final class JsonRpcRequestBuilder {
      *
      * @param method JSON-RPC method name
      * @return notification builder
-     * @throws NullPointerException if {@code method} is {@code null}
+     * @throws NullPointerException     if {@code method} is {@code null}
      * @throws IllegalArgumentException if {@code method} is blank or uses the reserved {@code rpc.*} namespace
      */
     public static JsonRpcRequestBuilder notification(String method) {
         return new JsonRpcRequestBuilder(method, true);
+    }
+
+    private static String validateMethod(String method) {
+        Objects.requireNonNull(method, "method");
+        if (method.isBlank()) {
+            throw new IllegalArgumentException("method must not be blank");
+        }
+        if (method.startsWith(JsonRpcConstants.RESERVED_METHOD_PREFIX)) {
+            throw new IllegalArgumentException("method must not use the reserved 'rpc.' namespace");
+        }
+        return method;
+    }
+
+    /**
+     * Recursively copies container nodes while reusing immutable scalar nodes.
+     * <p>
+     * This builder snapshots {@code params} both at assignment time and at build time:
+     * </p>
+     * <ul>
+     *   <li>assignment-time snapshot protects builder state from later mutations to caller-owned input nodes</li>
+     *   <li>build-time snapshot protects builder state from later mutations to the returned payload node</li>
+     * </ul>
+     *
+     * @param value node to snapshot
+     * @return detached node tree for container values, or the same instance for scalar values
+     */
+    private static JsonNode snapshot(JsonNode value) {
+        if (value.isObject()) {
+            ObjectNode copy = NODE_FACTORY.objectNode();
+            value.forEachEntry((name, child) -> copy.set(name, snapshot(child)));
+            return copy;
+        }
+        if (value.isArray()) {
+            ArrayNode copy = NODE_FACTORY.arrayNode();
+            for (JsonNode child : value) {
+                copy.add(snapshot(child));
+            }
+            return copy;
+        }
+        return value;
     }
 
     /**
@@ -72,7 +112,7 @@ public final class JsonRpcRequestBuilder {
      *
      * @param value string request id
      * @return this builder
-     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws NullPointerException  if {@code value} is {@code null}
      * @throws IllegalStateException if this builder represents a notification or the id has already been configured
      */
     public JsonRpcRequestBuilder id(String value) {
@@ -84,9 +124,9 @@ public final class JsonRpcRequestBuilder {
      *
      * @param value JSON id node; must be string, number, or null
      * @return this builder
-     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws NullPointerException     if {@code value} is {@code null}
      * @throws IllegalArgumentException if {@code value} is not a JSON-RPC-compatible id node
-     * @throws IllegalStateException if this builder represents a notification or the id has already been configured
+     * @throws IllegalStateException    if this builder represents a notification or the id has already been configured
      */
     public JsonRpcRequestBuilder id(JsonNode value) {
         Objects.requireNonNull(value, "value");
@@ -109,15 +149,15 @@ public final class JsonRpcRequestBuilder {
     /**
      * Sets {@code params} from a prebuilt JSON node.
      * <p>
-     * The provided node is snapshotted when assigned so that later caller-side mutations do not leak into the
-     * builder's internal state.
+     * The provided node is snapshotted when assigned so that later caller-side mutations do not leak into the builder's
+     * internal state.
      * </p>
      *
      * @param value params node; must be an object or array
      * @return this builder
-     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws NullPointerException     if {@code value} is {@code null}
      * @throws IllegalArgumentException if {@code value} is not an object or array
-     * @throws IllegalStateException if params have already been configured on this builder
+     * @throws IllegalStateException    if params have already been configured on this builder
      */
     public JsonRpcRequestBuilder params(JsonNode value) {
         Objects.requireNonNull(value, "value");
@@ -132,7 +172,7 @@ public final class JsonRpcRequestBuilder {
      *
      * @param elements array entries to add; {@code null} entries become JSON nulls
      * @return this builder
-     * @throws NullPointerException if {@code elements} is {@code null}
+     * @throws NullPointerException  if {@code elements} is {@code null}
      * @throws IllegalStateException if params have already been configured on this builder
      */
     public JsonRpcRequestBuilder paramsArray(JsonNode... elements) {
@@ -149,7 +189,7 @@ public final class JsonRpcRequestBuilder {
      *
      * @param configurator callback that populates the created object node
      * @return this builder
-     * @throws NullPointerException if {@code configurator} is {@code null}
+     * @throws NullPointerException  if {@code configurator} is {@code null}
      * @throws IllegalStateException if params have already been configured on this builder
      */
     public JsonRpcRequestBuilder paramsObject(Consumer<ObjectNode> configurator) {
@@ -205,45 +245,5 @@ public final class JsonRpcRequestBuilder {
         this.params = value;
         this.paramsConfigured = true;
         return this;
-    }
-
-    private static String validateMethod(String method) {
-        Objects.requireNonNull(method, "method");
-        if (method.isBlank()) {
-            throw new IllegalArgumentException("method must not be blank");
-        }
-        if (method.startsWith(JsonRpcConstants.RESERVED_METHOD_PREFIX)) {
-            throw new IllegalArgumentException("method must not use the reserved 'rpc.' namespace");
-        }
-        return method;
-    }
-
-    /**
-     * Recursively copies container nodes while reusing immutable scalar nodes.
-     * <p>
-     * This builder snapshots {@code params} both at assignment time and at build time:
-     * </p>
-     * <ul>
-     *   <li>assignment-time snapshot protects builder state from later mutations to caller-owned input nodes</li>
-     *   <li>build-time snapshot protects builder state from later mutations to the returned payload node</li>
-     * </ul>
-     *
-     * @param value node to snapshot
-     * @return detached node tree for container values, or the same instance for scalar values
-     */
-    private static JsonNode snapshot(JsonNode value) {
-        if (value.isObject()) {
-            ObjectNode copy = NODE_FACTORY.objectNode();
-            value.forEachEntry((name, child) -> copy.set(name, snapshot(child)));
-            return copy;
-        }
-        if (value.isArray()) {
-            ArrayNode copy = NODE_FACTORY.arrayNode();
-            for (JsonNode child : value) {
-                copy.add(snapshot(child));
-            }
-            return copy;
-        }
-        return value;
     }
 }

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
@@ -1,0 +1,226 @@
+package com.limehee.jsonrpc.core;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Builder for composing outbound JSON-RPC request and notification payloads.
+ * <p>
+ * This builder produces transport-ready Jackson nodes rather than parsed dispatcher models. It is intended for code
+ * that needs to send JSON-RPC payloads to another endpoint.
+ * </p>
+ */
+public final class JsonRpcRequestBuilder {
+
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+
+    private final String method;
+    private final boolean notification;
+
+    private @Nullable JsonNode id;
+    private boolean idConfigured;
+    private @Nullable JsonNode params;
+    private boolean paramsConfigured;
+
+    private JsonRpcRequestBuilder(String method, boolean notification) {
+        this.method = validateMethod(method);
+        this.notification = notification;
+    }
+
+    /**
+     * Creates a builder for a request that must include an {@code id}.
+     *
+     * @param method JSON-RPC method name
+     * @return request builder
+     * @throws IllegalArgumentException if {@code method} is blank or uses the reserved {@code rpc.*} namespace
+     */
+    public static JsonRpcRequestBuilder request(String method) {
+        return new JsonRpcRequestBuilder(method, false);
+    }
+
+    /**
+     * Creates a builder for a notification that must not include an {@code id}.
+     *
+     * @param method JSON-RPC method name
+     * @return notification builder
+     * @throws IllegalArgumentException if {@code method} is blank or uses the reserved {@code rpc.*} namespace
+     */
+    public static JsonRpcRequestBuilder notification(String method) {
+        return new JsonRpcRequestBuilder(method, true);
+    }
+
+    /**
+     * Sets a numeric {@code id}.
+     *
+     * @param value numeric request id
+     * @return this builder
+     * @throws IllegalStateException if this builder represents a notification or the id has already been configured
+     */
+    public JsonRpcRequestBuilder id(long value) {
+        return assignId(NODE_FACTORY.numberNode(value));
+    }
+
+    /**
+     * Sets a string {@code id}.
+     *
+     * @param value string request id
+     * @return this builder
+     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws IllegalStateException if this builder represents a notification or the id has already been configured
+     */
+    public JsonRpcRequestBuilder id(String value) {
+        return assignId(NODE_FACTORY.stringNode(Objects.requireNonNull(value, "value")));
+    }
+
+    /**
+     * Sets an explicit JSON {@code id} node.
+     *
+     * @param value JSON id node; must be string, number, or null
+     * @return this builder
+     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws IllegalArgumentException if {@code value} is not a JSON-RPC-compatible id node
+     * @throws IllegalStateException if this builder represents a notification or the id has already been configured
+     */
+    public JsonRpcRequestBuilder id(JsonNode value) {
+        Objects.requireNonNull(value, "value");
+        if (!value.isString() && !value.isNumber() && !value.isNull()) {
+            throw new IllegalArgumentException("id must be a string, number, or null JSON node");
+        }
+        return assignId(value);
+    }
+
+    /**
+     * Sets an explicit {@code null} id.
+     *
+     * @return this builder
+     * @throws IllegalStateException if this builder represents a notification or the id has already been configured
+     */
+    public JsonRpcRequestBuilder nullId() {
+        return assignId(NODE_FACTORY.nullNode());
+    }
+
+    /**
+     * Sets {@code params} from a prebuilt JSON node.
+     *
+     * @param value params node; must be an object or array
+     * @return this builder
+     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws IllegalArgumentException if {@code value} is not an object or array
+     * @throws IllegalStateException if params have already been configured on this builder
+     */
+    public JsonRpcRequestBuilder params(JsonNode value) {
+        Objects.requireNonNull(value, "value");
+        if (!value.isObject() && !value.isArray()) {
+            throw new IllegalArgumentException("params must be an object or array JSON node");
+        }
+        return assignParams(snapshot(value));
+    }
+
+    /**
+     * Sets array-style {@code params}.
+     *
+     * @param elements array entries to add; {@code null} entries become JSON nulls
+     * @return this builder
+     * @throws NullPointerException if {@code elements} is {@code null}
+     * @throws IllegalStateException if params have already been configured on this builder
+     */
+    public JsonRpcRequestBuilder paramsArray(JsonNode... elements) {
+        Objects.requireNonNull(elements, "elements");
+        ArrayNode arrayNode = NODE_FACTORY.arrayNode();
+        for (JsonNode element : elements) {
+            arrayNode.add(element == null ? NODE_FACTORY.nullNode() : snapshot(element));
+        }
+        return assignParams(arrayNode);
+    }
+
+    /**
+     * Sets object-style {@code params}.
+     *
+     * @param configurator callback that populates the created object node
+     * @return this builder
+     * @throws NullPointerException if {@code configurator} is {@code null}
+     * @throws IllegalStateException if params have already been configured on this builder
+     */
+    public JsonRpcRequestBuilder paramsObject(Consumer<ObjectNode> configurator) {
+        Objects.requireNonNull(configurator, "configurator");
+        ObjectNode objectNode = NODE_FACTORY.objectNode();
+        configurator.accept(objectNode);
+        return assignParams(objectNode);
+    }
+
+    /**
+     * Builds an outbound JSON-RPC request or notification payload.
+     *
+     * @return transport-ready JSON object node
+     * @throws IllegalStateException if this builder represents a request and no id has been configured
+     */
+    public ObjectNode buildNode() {
+        if (!notification && !idConfigured) {
+            throw new IllegalStateException("Requests must define an id before buildNode()");
+        }
+
+        ObjectNode node = NODE_FACTORY.objectNode();
+        node.put("jsonrpc", JsonRpcConstants.VERSION);
+        node.put("method", method);
+        if (idConfigured) {
+            node.set("id", Objects.requireNonNull(id, "id"));
+        }
+        if (paramsConfigured) {
+            node.set("params", snapshot(Objects.requireNonNull(params, "params")));
+        }
+        return node;
+    }
+
+    private JsonRpcRequestBuilder assignId(JsonNode value) {
+        if (notification) {
+            throw new IllegalStateException("Notifications must not define an id");
+        }
+        if (idConfigured) {
+            throw new IllegalStateException("id has already been configured");
+        }
+        this.id = value;
+        this.idConfigured = true;
+        return this;
+    }
+
+    private JsonRpcRequestBuilder assignParams(JsonNode value) {
+        if (paramsConfigured) {
+            throw new IllegalStateException("params have already been configured");
+        }
+        this.params = value;
+        this.paramsConfigured = true;
+        return this;
+    }
+
+    private static String validateMethod(String method) {
+        Objects.requireNonNull(method, "method");
+        if (method.isBlank()) {
+            throw new IllegalArgumentException("method must not be blank");
+        }
+        if (method.startsWith(JsonRpcConstants.RESERVED_METHOD_PREFIX)) {
+            throw new IllegalArgumentException("method must not use the reserved 'rpc.' namespace");
+        }
+        return method;
+    }
+
+    private static JsonNode snapshot(JsonNode value) {
+        if (value.isObject()) {
+            ObjectNode copy = NODE_FACTORY.objectNode();
+            value.asObject().forEachEntry((name, child) -> copy.set(name, snapshot(child)));
+            return copy;
+        }
+        if (value.isArray()) {
+            ArrayNode copy = NODE_FACTORY.arrayNode();
+            for (JsonNode child : value) {
+                copy.add(snapshot(child));
+            }
+            return copy;
+        }
+        return value;
+    }
+}

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
@@ -234,7 +234,7 @@ public final class JsonRpcRequestBuilder {
     private static JsonNode snapshot(JsonNode value) {
         if (value.isObject()) {
             ObjectNode copy = NODE_FACTORY.objectNode();
-            value.asObject().forEachEntry((name, child) -> copy.set(name, snapshot(child)));
+            value.forEachEntry((name, child) -> copy.set(name, snapshot(child)));
             return copy;
         }
         if (value.isArray()) {

--- a/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
+++ b/jsonrpc-core/src/main/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilder.java
@@ -106,6 +106,10 @@ public final class JsonRpcRequestBuilder {
 
     /**
      * Sets {@code params} from a prebuilt JSON node.
+     * <p>
+     * The provided node is snapshotted when assigned so that later caller-side mutations do not leak into the
+     * builder's internal state.
+     * </p>
      *
      * @param value params node; must be an object or array
      * @return this builder
@@ -155,6 +159,10 @@ public final class JsonRpcRequestBuilder {
 
     /**
      * Builds an outbound JSON-RPC request or notification payload.
+     * <p>
+     * A fresh snapshot of the configured {@code params} is written into the returned node so that mutations applied to
+     * a built payload do not affect subsequent {@code buildNode()} calls on the same builder.
+     * </p>
      *
      * @return transport-ready JSON object node
      * @throws IllegalStateException if this builder represents a request and no id has been configured
@@ -208,6 +216,19 @@ public final class JsonRpcRequestBuilder {
         return method;
     }
 
+    /**
+     * Recursively copies container nodes while reusing immutable scalar nodes.
+     * <p>
+     * This builder snapshots {@code params} both at assignment time and at build time:
+     * </p>
+     * <ul>
+     *   <li>assignment-time snapshot protects builder state from later mutations to caller-owned input nodes</li>
+     *   <li>build-time snapshot protects builder state from later mutations to the returned payload node</li>
+     * </ul>
+     *
+     * @param value node to snapshot
+     * @return detached node tree for container values, or the same instance for scalar values
+     */
     private static JsonNode snapshot(JsonNode value) {
         if (value.isObject()) {
             ObjectNode copy = NODE_FACTORY.objectNode();

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcErrorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcErrorTest.java
@@ -1,12 +1,22 @@
 package com.limehee.jsonrpc.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.IntNode;
 
 class JsonRpcErrorTest {
+
+    @Test
+    void ofWithoutDataCreatesErrorWithNullData() {
+        JsonRpcError error = JsonRpcError.of(JsonRpcErrorCode.INTERNAL_ERROR, "boom");
+
+        assertEquals(JsonRpcErrorCode.INTERNAL_ERROR, error.code());
+        assertEquals("boom", error.message());
+        assertNull(error.data());
+    }
 
     @Test
     void ofWithDataCreatesErrorWithProvidedData() {
@@ -17,5 +27,14 @@ class JsonRpcErrorTest {
         assertEquals(JsonRpcErrorCode.INTERNAL_ERROR, error.code());
         assertEquals("boom", error.message());
         assertSame(data, error.data());
+    }
+
+    @Test
+    void ofWithExplicitNullDataKeepsNullData() {
+        JsonRpcError error = JsonRpcError.of(JsonRpcErrorCode.INTERNAL_ERROR, "boom", null);
+
+        assertEquals(JsonRpcErrorCode.INTERNAL_ERROR, error.code());
+        assertEquals("boom", error.message());
+        assertNull(error.data());
     }
 }

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcErrorTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcErrorTest.java
@@ -1,0 +1,21 @@
+package com.limehee.jsonrpc.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.IntNode;
+
+class JsonRpcErrorTest {
+
+    @Test
+    void ofWithDataCreatesErrorWithProvidedData() {
+        IntNode data = IntNode.valueOf(99);
+
+        JsonRpcError error = JsonRpcError.of(JsonRpcErrorCode.INTERNAL_ERROR, "boom", data);
+
+        assertEquals(JsonRpcErrorCode.INTERNAL_ERROR, error.code());
+        assertEquals("boom", error.message());
+        assertSame(data, error.data());
+    }
+}

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilderTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilderTest.java
@@ -2,11 +2,14 @@ package com.limehee.jsonrpc.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.JsonNodeFactory;
 import tools.jackson.databind.node.ObjectNode;
 
 class JsonRpcRequestBatchBuilderTest {
@@ -65,6 +68,15 @@ class JsonRpcRequestBatchBuilderTest {
     }
 
     @Test
+    void addRequestRejectsNullOrInvalidMethod() {
+        JsonRpcRequestBatchBuilder batchBuilder = new JsonRpcRequestBatchBuilder();
+
+        assertThrows(NullPointerException.class, () -> batchBuilder.addRequest(null, request -> request.id(1L)));
+        assertThrows(IllegalArgumentException.class, () -> batchBuilder.addRequest(" ", request -> request.id(1L)));
+        assertThrows(IllegalArgumentException.class, () -> batchBuilder.addRequest("rpc.system", request -> request.id(1L)));
+    }
+
+    @Test
     void addNotificationAppliesCustomizer() {
         var batch = new JsonRpcRequestBatchBuilder()
             .addNotification("typed.tags", request -> request.paramsArray(IntNode.valueOf(1)))
@@ -84,10 +96,52 @@ class JsonRpcRequestBatchBuilderTest {
     }
 
     @Test
+    void addNotificationRejectsNullOrInvalidMethod() {
+        JsonRpcRequestBatchBuilder batchBuilder = new JsonRpcRequestBatchBuilder();
+
+        assertThrows(NullPointerException.class, () -> batchBuilder.addNotification(null, request -> { }));
+        assertThrows(IllegalArgumentException.class, () -> batchBuilder.addNotification(" ", request -> { }));
+        assertThrows(IllegalArgumentException.class, () -> batchBuilder.addNotification("rpc.system", request -> { }));
+    }
+
+    @Test
     void buildBatchNodePropagatesInvalidRequestBuilderState() {
         JsonRpcRequestBatchBuilder batchBuilder = new JsonRpcRequestBatchBuilder()
             .add(JsonRpcRequestBuilder.request("ping"));
 
         assertThrows(IllegalStateException.class, batchBuilder::buildNode);
+    }
+
+    @Test
+    void buildBatchNodeReturnsDetachedPayloadAcrossBuilderReuse() {
+        JsonRpcRequestBatchBuilder batchBuilder = new JsonRpcRequestBatchBuilder()
+            .addRequest("state.read", request -> request
+                .id(1L)
+                .paramsObject(params -> params.put("status", "initial")));
+
+        ArrayNode first = batchBuilder.buildNode();
+        ((ObjectNode) first.get(0).get("params")).put("status", "mutated");
+
+        ArrayNode second = batchBuilder.buildNode();
+
+        assertEquals("initial", second.get(0).get("params").get("status").stringValue());
+        assertNotSame(first, second);
+        assertNotSame(first.get(0), second.get(0));
+        assertNotSame(first.get(0).get("params"), second.get(0).get("params"));
+    }
+
+    @Test
+    void addNotificationCanBuildObjectParams() {
+        var batch = new JsonRpcRequestBatchBuilder()
+            .addNotification("audit.record", request -> request.paramsObject(params -> {
+                params.put("event", "created");
+                params.put("source", "gateway");
+            }))
+            .buildNode();
+
+        ObjectNode request = (ObjectNode) batch.get(0);
+        assertFalse(request.has("id"));
+        assertEquals("created", request.get("params").get("event").stringValue());
+        assertEquals("gateway", request.get("params").get("source").stringValue());
     }
 }

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilderTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilderTest.java
@@ -1,6 +1,7 @@
 package com.limehee.jsonrpc.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,7 +22,7 @@ class JsonRpcRequestBatchBuilderTest {
         assertEquals("ping", batch.get(0).get("method").stringValue());
         assertEquals(1L, batch.get(0).get("id").longValue());
         assertEquals("notify.mark", batch.get(1).get("method").stringValue());
-        assertTrue(batch.get(1).get("id") == null);
+        assertFalse(batch.get(1).has("id"));
     }
 
     @Test
@@ -71,7 +72,7 @@ class JsonRpcRequestBatchBuilderTest {
 
         ObjectNode request = (ObjectNode) batch.get(0);
         assertEquals("typed.tags", request.get("method").stringValue());
-        assertTrue(request.get("id") == null);
+        assertFalse(request.has("id"));
         assertEquals(1, request.get("params").get(0).intValue());
     }
 

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilderTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilderTest.java
@@ -4,12 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.IntNode;
-import tools.jackson.databind.node.JsonNodeFactory;
 import tools.jackson.databind.node.ObjectNode;
 
 class JsonRpcRequestBatchBuilderTest {
@@ -73,7 +71,8 @@ class JsonRpcRequestBatchBuilderTest {
 
         assertThrows(NullPointerException.class, () -> batchBuilder.addRequest(null, request -> request.id(1L)));
         assertThrows(IllegalArgumentException.class, () -> batchBuilder.addRequest(" ", request -> request.id(1L)));
-        assertThrows(IllegalArgumentException.class, () -> batchBuilder.addRequest("rpc.system", request -> request.id(1L)));
+        assertThrows(IllegalArgumentException.class,
+            () -> batchBuilder.addRequest("rpc.system", request -> request.id(1L)));
     }
 
     @Test
@@ -99,9 +98,12 @@ class JsonRpcRequestBatchBuilderTest {
     void addNotificationRejectsNullOrInvalidMethod() {
         JsonRpcRequestBatchBuilder batchBuilder = new JsonRpcRequestBatchBuilder();
 
-        assertThrows(NullPointerException.class, () -> batchBuilder.addNotification(null, request -> { }));
-        assertThrows(IllegalArgumentException.class, () -> batchBuilder.addNotification(" ", request -> { }));
-        assertThrows(IllegalArgumentException.class, () -> batchBuilder.addNotification("rpc.system", request -> { }));
+        assertThrows(NullPointerException.class, () -> batchBuilder.addNotification(null, request -> {
+        }));
+        assertThrows(IllegalArgumentException.class, () -> batchBuilder.addNotification(" ", request -> {
+        }));
+        assertThrows(IllegalArgumentException.class, () -> batchBuilder.addNotification("rpc.system", request -> {
+        }));
     }
 
     @Test

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilderTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBatchBuilderTest.java
@@ -1,0 +1,92 @@
+package com.limehee.jsonrpc.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.ObjectNode;
+
+class JsonRpcRequestBatchBuilderTest {
+
+    @Test
+    void buildBatchNodeWithRequestAndNotificationEntries() {
+        var batch = new JsonRpcRequestBatchBuilder()
+            .add(JsonRpcRequestBuilder.request("ping").id(1L))
+            .add(JsonRpcRequestBuilder.notification("notify.mark"))
+            .buildNode();
+
+        assertEquals(2, batch.size());
+        assertEquals("ping", batch.get(0).get("method").stringValue());
+        assertEquals(1L, batch.get(0).get("id").longValue());
+        assertEquals("notify.mark", batch.get(1).get("method").stringValue());
+        assertTrue(batch.get(1).get("id") == null);
+    }
+
+    @Test
+    void buildBatchNodeRejectsEmptyBatch() {
+        assertThrows(
+            IllegalStateException.class,
+            () -> new JsonRpcRequestBatchBuilder().buildNode()
+        );
+    }
+
+    @Test
+    void addRejectsNullBuilder() {
+        JsonRpcRequestBatchBuilder batchBuilder = new JsonRpcRequestBatchBuilder();
+
+        assertThrows(NullPointerException.class, () -> batchBuilder.add(null));
+    }
+
+    @Test
+    void addRequestAppliesCustomizer() {
+        var batch = new JsonRpcRequestBatchBuilder()
+            .addRequest("sum", request -> request
+                .id(10L)
+                .paramsObject(params -> {
+                    params.put("left", 4);
+                    params.put("right", 6);
+                }))
+            .buildNode();
+
+        ObjectNode request = (ObjectNode) batch.get(0);
+        assertEquals(10L, request.get("id").longValue());
+        assertEquals(4, request.get("params").get("left").intValue());
+        assertEquals(6, request.get("params").get("right").intValue());
+    }
+
+    @Test
+    void addRequestRejectsNullCustomizer() {
+        JsonRpcRequestBatchBuilder batchBuilder = new JsonRpcRequestBatchBuilder();
+
+        assertThrows(NullPointerException.class, () -> batchBuilder.addRequest("sum", null));
+    }
+
+    @Test
+    void addNotificationAppliesCustomizer() {
+        var batch = new JsonRpcRequestBatchBuilder()
+            .addNotification("typed.tags", request -> request.paramsArray(IntNode.valueOf(1)))
+            .buildNode();
+
+        ObjectNode request = (ObjectNode) batch.get(0);
+        assertEquals("typed.tags", request.get("method").stringValue());
+        assertTrue(request.get("id") == null);
+        assertEquals(1, request.get("params").get(0).intValue());
+    }
+
+    @Test
+    void addNotificationRejectsNullCustomizer() {
+        JsonRpcRequestBatchBuilder batchBuilder = new JsonRpcRequestBatchBuilder();
+
+        assertThrows(NullPointerException.class, () -> batchBuilder.addNotification("typed.tags", null));
+    }
+
+    @Test
+    void buildBatchNodePropagatesInvalidRequestBuilderState() {
+        JsonRpcRequestBatchBuilder batchBuilder = new JsonRpcRequestBatchBuilder()
+            .add(JsonRpcRequestBuilder.request("ping"));
+
+        assertThrows(IllegalStateException.class, batchBuilder::buildNode);
+    }
+}

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilderTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilderTest.java
@@ -1,0 +1,183 @@
+package com.limehee.jsonrpc.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
+
+class JsonRpcRequestBuilderTest {
+
+    @Test
+    void buildRequestNodeWithObjectParamsAndLongId() {
+        ObjectNode node = JsonRpcRequestBuilder.request("sum")
+            .id(7L)
+            .paramsObject(params -> {
+                params.put("left", 2);
+                params.put("right", 5);
+            })
+            .buildNode();
+
+        assertEquals("2.0", node.get("jsonrpc").stringValue());
+        assertEquals("sum", node.get("method").stringValue());
+        assertEquals(7L, node.get("id").longValue());
+        assertEquals(2, node.get("params").get("left").intValue());
+        assertEquals(5, node.get("params").get("right").intValue());
+    }
+
+    @Test
+    void buildNotificationNodeWithoutId() {
+        ObjectNode node = JsonRpcRequestBuilder.notification("heartbeat")
+            .buildNode();
+
+        assertEquals("2.0", node.get("jsonrpc").stringValue());
+        assertEquals("heartbeat", node.get("method").stringValue());
+        assertFalse(node.has("id"));
+    }
+
+    @Test
+    void buildRequestNodeWithExplicitNullId() {
+        ObjectNode node = JsonRpcRequestBuilder.request("ping")
+            .nullId()
+            .buildNode();
+
+        assertTrue(node.has("id"));
+        assertTrue(node.get("id").isNull());
+    }
+
+    @Test
+    void buildRequestNodeWithStringId() {
+        ObjectNode node = JsonRpcRequestBuilder.request("lookup")
+            .id("request-7")
+            .buildNode();
+
+        assertEquals("request-7", node.get("id").stringValue());
+    }
+
+    @Test
+    void buildRequestNodeWithJsonNodeId() {
+        ObjectNode node = JsonRpcRequestBuilder.request("lookup")
+            .id(IntNode.valueOf(12))
+            .buildNode();
+
+        assertEquals(12, node.get("id").intValue());
+    }
+
+    @Test
+    void requestBuildNodeRejectsMissingId() {
+        assertThrows(
+            IllegalStateException.class,
+            () -> JsonRpcRequestBuilder.request("ping").buildNode()
+        );
+    }
+
+    @Test
+    void notificationRejectsIdAssignment() {
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.notification("ping");
+
+        assertThrows(IllegalStateException.class, () -> builder.id(1L));
+        assertThrows(IllegalStateException.class, builder::nullId);
+    }
+
+    @Test
+    void requestRejectsRepeatedIdAssignment() {
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.request("ping").id(1L);
+
+        assertThrows(IllegalStateException.class, () -> builder.id(2L));
+    }
+
+    @Test
+    void requestRejectsRepeatedParamsConfiguration() {
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.request("ping")
+            .id(1L)
+            .paramsObject(params -> params.put("value", "first"));
+
+        assertThrows(
+            IllegalStateException.class,
+            () -> builder.paramsArray(IntNode.valueOf(1))
+        );
+        assertThrows(
+            IllegalStateException.class,
+            () -> builder.paramsObject(params -> params.put("value", "second"))
+        );
+    }
+
+    @Test
+    void paramsRejectPrimitiveNode() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JsonRpcRequestBuilder.request("ping").id(1L).params(IntNode.valueOf(3))
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JsonRpcRequestBuilder.request("ping").id(1L).params(NullNode.getInstance())
+        );
+    }
+
+    @Test
+    void paramsAcceptArrayNode() {
+        ArrayNode params = JsonNodeFactory.instance.arrayNode()
+            .add(1)
+            .add(2);
+
+        ObjectNode node = JsonRpcRequestBuilder.request("sum")
+            .id(1L)
+            .params(params)
+            .buildNode();
+
+        assertTrue(node.get("params").isArray());
+        assertEquals(1, node.get("params").get(0).intValue());
+        assertEquals(2, node.get("params").get(1).intValue());
+    }
+
+    @Test
+    void paramsSnapshotPreventsOriginalObjectMutationFromLeakingIntoBuiltPayload() {
+        ObjectNode params = JsonNodeFactory.instance.objectNode();
+        params.put("status", "initial");
+
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.request("state.read")
+            .id(1L)
+            .params(params);
+
+        params.put("status", "mutated");
+
+        ObjectNode node = builder.buildNode();
+
+        assertEquals("initial", node.get("params").get("status").stringValue());
+        assertNotSame(params, node.get("params"));
+    }
+
+    @Test
+    void idRejectsNonScalarNode() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JsonRpcRequestBuilder.request("ping").id(JsonNodeFactory.instance.objectNode())
+        );
+    }
+
+    @Test
+    void paramsArrayCreatesArrayNodeAndPreservesNullEntries() {
+        ObjectNode node = JsonRpcRequestBuilder.request("sum")
+            .id(1L)
+            .paramsArray(IntNode.valueOf(1), null, IntNode.valueOf(3))
+            .buildNode();
+
+        assertTrue(node.get("params").isArray());
+        assertEquals(1, node.get("params").get(0).intValue());
+        assertTrue(node.get("params").get(1).isNull());
+        assertEquals(3, node.get("params").get(2).intValue());
+    }
+
+    @Test
+    void requestRejectsBlankOrReservedMethodNames() {
+        assertThrows(IllegalArgumentException.class, () -> JsonRpcRequestBuilder.request(" "));
+        assertThrows(IllegalArgumentException.class, () -> JsonRpcRequestBuilder.request("rpc.system"));
+    }
+}

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilderTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilderTest.java
@@ -44,6 +44,17 @@ class JsonRpcRequestBuilderTest {
     }
 
     @Test
+    void buildNotificationNodeWithObjectParams() {
+        ObjectNode node = JsonRpcRequestBuilder.notification("audit.record")
+            .paramsObject(params -> params.put("event", "created"))
+            .buildNode();
+
+        assertFalse(node.has("id"));
+        assertTrue(node.has("params"));
+        assertEquals("created", node.get("params").get("event").stringValue());
+    }
+
+    @Test
     void buildRequestNodeWithExplicitNullId() {
         ObjectNode node = JsonRpcRequestBuilder.request("ping")
             .nullId()
@@ -60,6 +71,7 @@ class JsonRpcRequestBuilderTest {
             .buildNode();
 
         assertEquals("request-7", node.get("id").stringValue());
+        assertFalse(node.has("params"));
     }
 
     @Test
@@ -69,6 +81,16 @@ class JsonRpcRequestBuilderTest {
             .buildNode();
 
         assertEquals(12, node.get("id").intValue());
+    }
+
+    @Test
+    void requestRejectsNullMethod() {
+        assertThrows(NullPointerException.class, () -> JsonRpcRequestBuilder.request(null));
+    }
+
+    @Test
+    void notificationRejectsNullMethod() {
+        assertThrows(NullPointerException.class, () -> JsonRpcRequestBuilder.notification(null));
     }
 
     @Test
@@ -94,6 +116,8 @@ class JsonRpcRequestBuilderTest {
         JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.request("ping").id(1L);
 
         assertThrows(IllegalStateException.class, () -> builder.id(2L));
+        assertThrows(IllegalStateException.class, () -> builder.id("request-2"));
+        assertThrows(IllegalStateException.class, builder::nullId);
     }
 
     @Test
@@ -110,6 +134,27 @@ class JsonRpcRequestBuilderTest {
             IllegalStateException.class,
             () -> builder.paramsObject(params -> params.put("value", "second"))
         );
+        assertThrows(
+            IllegalStateException.class,
+            () -> builder.params(JsonNodeFactory.instance.objectNode())
+        );
+    }
+
+    @Test
+    void idRejectsNullInputs() {
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.request("ping");
+
+        assertThrows(NullPointerException.class, () -> builder.id((String) null));
+        assertThrows(NullPointerException.class, () -> builder.id((JsonNode) null));
+    }
+
+    @Test
+    void paramsRejectNullInputs() {
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.request("ping").id(1L);
+
+        assertThrows(NullPointerException.class, () -> builder.params((JsonNode) null));
+        assertThrows(NullPointerException.class, () -> builder.paramsArray((JsonNode[]) null));
+        assertThrows(NullPointerException.class, () -> builder.paramsObject(null));
     }
 
     @Test
@@ -141,6 +186,20 @@ class JsonRpcRequestBuilderTest {
     }
 
     @Test
+    void paramsAcceptObjectNode() {
+        ObjectNode params = JsonNodeFactory.instance.objectNode();
+        params.put("status", "ready");
+
+        ObjectNode node = JsonRpcRequestBuilder.request("state.read")
+            .id(1L)
+            .params(params)
+            .buildNode();
+
+        assertTrue(node.get("params").isObject());
+        assertEquals("ready", node.get("params").get("status").stringValue());
+    }
+
+    @Test
     void paramsSnapshotPreventsOriginalObjectMutationFromLeakingIntoBuiltPayload() {
         ObjectNode params = JsonNodeFactory.instance.objectNode();
         params.put("status", "initial");
@@ -154,6 +213,22 @@ class JsonRpcRequestBuilderTest {
         ObjectNode node = builder.buildNode();
 
         assertEquals("initial", node.get("params").get("status").stringValue());
+        assertNotSame(params, node.get("params"));
+    }
+
+    @Test
+    void paramsSnapshotPreventsOriginalArrayMutationFromLeakingIntoBuiltPayload() {
+        ArrayNode params = JsonNodeFactory.instance.arrayNode().add("first");
+
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.request("tags.list")
+            .id(1L)
+            .params(params);
+
+        params.set(0, JsonNodeFactory.instance.stringNode("mutated"));
+
+        ObjectNode node = builder.buildNode();
+
+        assertEquals("first", node.get("params").get(0).stringValue());
         assertNotSame(params, node.get("params"));
     }
 
@@ -198,5 +273,7 @@ class JsonRpcRequestBuilderTest {
     void requestRejectsBlankOrReservedMethodNames() {
         assertThrows(IllegalArgumentException.class, () -> JsonRpcRequestBuilder.request(" "));
         assertThrows(IllegalArgumentException.class, () -> JsonRpcRequestBuilder.request("rpc.system"));
+        assertThrows(IllegalArgumentException.class, () -> JsonRpcRequestBuilder.notification(" "));
+        assertThrows(IllegalArgumentException.class, () -> JsonRpcRequestBuilder.notification("rpc.system"));
     }
 }

--- a/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilderTest.java
+++ b/jsonrpc-core/src/test/java/com/limehee/jsonrpc/core/JsonRpcRequestBuilderTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.IntNode;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -83,6 +84,8 @@ class JsonRpcRequestBuilderTest {
         JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.notification("ping");
 
         assertThrows(IllegalStateException.class, () -> builder.id(1L));
+        assertThrows(IllegalStateException.class, () -> builder.id("request-1"));
+        assertThrows(IllegalStateException.class, () -> builder.id(IntNode.valueOf(1)));
         assertThrows(IllegalStateException.class, builder::nullId);
     }
 
@@ -152,6 +155,22 @@ class JsonRpcRequestBuilderTest {
 
         assertEquals("initial", node.get("params").get("status").stringValue());
         assertNotSame(params, node.get("params"));
+    }
+
+    @Test
+    void buildNodeReturnsDetachedParamsSnapshotAcrossBuilderReuse() {
+        JsonRpcRequestBuilder builder = JsonRpcRequestBuilder.request("state.read")
+            .id(1L)
+            .paramsObject(params -> params.put("status", "initial"));
+
+        ObjectNode first = builder.buildNode();
+        JsonNode firstParams = first.get("params");
+        ((ObjectNode) firstParams).put("status", "mutated");
+
+        ObjectNode second = builder.buildNode();
+
+        assertEquals("initial", second.get("params").get("status").stringValue());
+        assertNotSame(first.get("params"), second.get("params"));
     }
 
     @Test

--- a/samples/pure-java-demo/README.md
+++ b/samples/pure-java-demo/README.md
@@ -33,6 +33,8 @@ From repository root:
   `reject-duplicate-members`, `error-code.policy`)
 - Incoming response-side flow using classifier/parser/validator utilities
 - Interceptor lifecycle flow (`beforeValidate`, `beforeInvoke`, `afterInvoke`, `onError`)
+- Outbound request composition using `JsonRpcRequestBuilder` and `JsonRpcRequestBatchBuilder`
+- Manual JSON-RPC error object composition using `JsonRpcError.of(code, message, data)`
 
 ## Key Class
 
@@ -40,5 +42,6 @@ From repository root:
 - `src/main/java/com/limehee/jsonrpc/sample/purejava/ResponseSideUtilitiesExample.java`
 - `src/main/java/com/limehee/jsonrpc/sample/purejava/InterceptorFlowExample.java`
 - `src/main/java/com/limehee/jsonrpc/sample/purejava/ValidationProfileExample.java`
+- `src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java`
 
 The `main` method prints one output payload per scenario so you can follow request -> dispatch -> response flow.

--- a/samples/pure-java-demo/README.md
+++ b/samples/pure-java-demo/README.md
@@ -34,6 +34,7 @@ From repository root:
 - Incoming response-side flow using classifier/parser/validator utilities
 - Interceptor lifecycle flow (`beforeValidate`, `beforeInvoke`, `afterInvoke`, `onError`)
 - Outbound request composition using `JsonRpcRequestBuilder` and `JsonRpcRequestBatchBuilder`
+- Direct `paramsObject(...)` and `paramsArray(...)` builder examples for outbound requests
 - Manual JSON-RPC error object composition using `JsonRpcError.of(code, message, data)`
 - Record, POJO, collection, and map params converted through Jackson and passed via `params(JsonNode)`
 

--- a/samples/pure-java-demo/README.md
+++ b/samples/pure-java-demo/README.md
@@ -35,7 +35,7 @@ From repository root:
 - Interceptor lifecycle flow (`beforeValidate`, `beforeInvoke`, `afterInvoke`, `onError`)
 - Outbound request composition using `JsonRpcRequestBuilder` and `JsonRpcRequestBatchBuilder`
 - Manual JSON-RPC error object composition using `JsonRpcError.of(code, message, data)`
-- Record, POJO, and collection params converted through Jackson and passed via `params(JsonNode)`
+- Record, POJO, collection, and map params converted through Jackson and passed via `params(JsonNode)`
 
 ## Key Class
 

--- a/samples/pure-java-demo/README.md
+++ b/samples/pure-java-demo/README.md
@@ -35,6 +35,7 @@ From repository root:
 - Interceptor lifecycle flow (`beforeValidate`, `beforeInvoke`, `afterInvoke`, `onError`)
 - Outbound request composition using `JsonRpcRequestBuilder` and `JsonRpcRequestBatchBuilder`
 - Manual JSON-RPC error object composition using `JsonRpcError.of(code, message, data)`
+- Record, POJO, and collection params converted through Jackson and passed via `params(JsonNode)`
 
 ## Key Class
 

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
@@ -3,17 +3,41 @@ package com.limehee.jsonrpc.sample.purejava;
 import com.limehee.jsonrpc.core.JsonRpcError;
 import com.limehee.jsonrpc.core.JsonRpcRequestBatchBuilder;
 import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+import java.util.List;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 import tools.jackson.databind.node.ObjectNode;
 
+/**
+ * Sample outbound JSON-RPC payload composition for plain Java applications.
+ */
 public final class OutboundRequestCompositionExample {
 
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
     private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
 
     private OutboundRequestCompositionExample() {
     }
 
+    /**
+     * Builds a request with object-style params using direct node composition.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "inventory.lookup",
+     *   "id": "req-7",
+     *   "params": {
+     *     "sku": "book-001",
+     *     "warehouse": "seoul"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
     public static ObjectNode buildInventoryLookupRequest() {
         return JsonRpcRequestBuilder.request("inventory.lookup")
             .id("req-7")
@@ -24,6 +48,91 @@ public final class OutboundRequestCompositionExample {
             .buildNode();
     }
 
+    /**
+     * Builds a request from a record converted through Jackson.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "inventory.lookup.record",
+     *   "id": 11,
+     *   "params": {
+     *     "sku": "book-002",
+     *     "warehouse": "busan"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildInventoryLookupRequestFromRecord() {
+        return JsonRpcRequestBuilder.request("inventory.lookup.record")
+            .id(11L)
+            .params(OBJECT_MAPPER.valueToTree(new InventoryLookupParams("book-002", "busan")))
+            .buildNode();
+    }
+
+    /**
+     * Builds a request from a classic Java class converted through Jackson.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "tag.create",
+     *   "id": 12,
+     *   "params": {
+     *     "name": "featured",
+     *     "color": "green"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildTagCreateRequestFromClass() {
+        return JsonRpcRequestBuilder.request("tag.create")
+            .id(12L)
+            .params(OBJECT_MAPPER.valueToTree(new TagCreateParams("featured", "green")))
+            .buildNode();
+    }
+
+    /**
+     * Builds a request whose params are a JSON array produced from a collection.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "tags.bulkLookup",
+     *   "id": 13,
+     *   "params": ["alpha", "beta", "gamma"]
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildBulkLookupRequestFromCollection() {
+        return JsonRpcRequestBuilder.request("tags.bulkLookup")
+            .id(13L)
+            .params(OBJECT_MAPPER.valueToTree(List.of("alpha", "beta", "gamma")))
+            .buildNode();
+    }
+
+    /**
+     * Builds a notification payload with object-style params.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "audit.record",
+     *   "params": {
+     *     "event": "inventory.lookup",
+     *     "source": "gateway"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return outbound notification payload
+     */
     public static ObjectNode buildAuditNotification() {
         return JsonRpcRequestBuilder.notification("audit.record")
             .paramsObject(params -> {
@@ -33,6 +142,29 @@ public final class OutboundRequestCompositionExample {
             .buildNode();
     }
 
+    /**
+     * Builds a mixed batch containing a request and a notification.
+     *
+     * <pre>{@code
+     * [
+     *   {
+     *     "jsonrpc": "2.0",
+     *     "method": "inventory.lookup",
+     *     "id": 1
+     *   },
+     *   {
+     *     "jsonrpc": "2.0",
+     *     "method": "audit.record",
+     *     "params": {
+     *       "event": "inventory.lookup",
+     *       "source": "gateway"
+     *     }
+     *   }
+     * ]
+     * }</pre>
+     *
+     * @return outbound batch payload
+     */
     public static ArrayNode buildOutboundBatch() {
         return new JsonRpcRequestBatchBuilder()
             .add(JsonRpcRequestBuilder.request("inventory.lookup").id(1L))
@@ -43,10 +175,48 @@ public final class OutboundRequestCompositionExample {
             .buildNode();
     }
 
+    /**
+     * Builds a structured JSON-RPC error object that can be embedded into a response payload.
+     *
+     * <pre>{@code
+     * {
+     *   "code": -32001,
+     *   "message": "Inventory upstream failed",
+     *   "data": {
+     *     "traceId": "trace-123",
+     *     "service": "inventory-gateway"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return JSON-RPC error object
+     */
     public static JsonRpcError buildUpstreamFailureError() {
         ObjectNode data = NODE_FACTORY.objectNode();
         data.put("traceId", "trace-123");
         data.put("service", "inventory-gateway");
         return JsonRpcError.of(-32001, "Inventory upstream failed", data);
+    }
+
+    public record InventoryLookupParams(String sku, String warehouse) {
+    }
+
+    public static final class TagCreateParams {
+
+        private final String name;
+        private final String color;
+
+        public TagCreateParams(String name, String color) {
+            this.name = name;
+            this.color = color;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getColor() {
+            return color;
+        }
     }
 }

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
@@ -1,0 +1,52 @@
+package com.limehee.jsonrpc.sample.purejava;
+
+import com.limehee.jsonrpc.core.JsonRpcError;
+import com.limehee.jsonrpc.core.JsonRpcRequestBatchBuilder;
+import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+
+public final class OutboundRequestCompositionExample {
+
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+
+    private OutboundRequestCompositionExample() {
+    }
+
+    public static ObjectNode buildInventoryLookupRequest() {
+        return JsonRpcRequestBuilder.request("inventory.lookup")
+            .id("req-7")
+            .paramsObject(params -> {
+                params.put("sku", "book-001");
+                params.put("warehouse", "seoul");
+            })
+            .buildNode();
+    }
+
+    public static ObjectNode buildAuditNotification() {
+        return JsonRpcRequestBuilder.notification("audit.record")
+            .paramsObject(params -> {
+                params.put("event", "inventory.lookup");
+                params.put("source", "gateway");
+            })
+            .buildNode();
+    }
+
+    public static ArrayNode buildOutboundBatch() {
+        return new JsonRpcRequestBatchBuilder()
+            .add(JsonRpcRequestBuilder.request("inventory.lookup").id(1L))
+            .addNotification("audit.record", request -> request.paramsObject(params -> {
+                params.put("event", "inventory.lookup");
+                params.put("source", "gateway");
+            }))
+            .buildNode();
+    }
+
+    public static JsonRpcError buildUpstreamFailureError() {
+        ObjectNode data = NODE_FACTORY.objectNode();
+        data.put("traceId", "trace-123");
+        data.put("service", "inventory-gateway");
+        return JsonRpcError.of(-32001, "Inventory upstream failed", data);
+    }
+}

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
@@ -252,6 +252,7 @@ public final class OutboundRequestCompositionExample {
     }
 
     public record InventoryLookupParams(String sku, String warehouse) {
+
     }
 
     public static final class TagCreateParams {

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
@@ -50,6 +50,31 @@ public final class OutboundRequestCompositionExample {
     }
 
     /**
+     * Builds a request with positional params using the dedicated array builder API.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "inventory.reserve",
+     *   "id": 10,
+     *   "params": ["book-001", 2, true]
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildInventoryReserveRequestWithParamsArray() {
+        return JsonRpcRequestBuilder.request("inventory.reserve")
+            .id(10L)
+            .paramsArray(
+                NODE_FACTORY.stringNode("book-001"),
+                NODE_FACTORY.numberNode(2),
+                NODE_FACTORY.booleanNode(true)
+            )
+            .buildNode();
+    }
+
+    /**
      * Builds a request from a record converted through Jackson.
      *
      * <pre>{@code

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExample.java
@@ -4,6 +4,7 @@ import com.limehee.jsonrpc.core.JsonRpcError;
 import com.limehee.jsonrpc.core.JsonRpcRequestBatchBuilder;
 import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
 import java.util.List;
+import java.util.Map;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
@@ -114,6 +115,33 @@ public final class OutboundRequestCompositionExample {
         return JsonRpcRequestBuilder.request("tags.bulkLookup")
             .id(13L)
             .params(OBJECT_MAPPER.valueToTree(List.of("alpha", "beta", "gamma")))
+            .buildNode();
+    }
+
+    /**
+     * Builds a request from a map converted through Jackson.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "health.snapshot",
+     *   "id": 14,
+     *   "params": {
+     *     "region": "ap-northeast-2",
+     *     "includeDetails": true
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildHealthSnapshotRequestFromMap() {
+        return JsonRpcRequestBuilder.request("health.snapshot")
+            .id(14L)
+            .params(OBJECT_MAPPER.valueToTree(Map.of(
+                "region", "ap-northeast-2",
+                "includeDetails", true
+            )))
             .buildNode();
     }
 

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
@@ -65,6 +65,18 @@ public final class PureJavaDemoApplication {
             {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"server"}}
             """);
         print("strict response profile", OBJECT_MAPPER.writeValueAsString(strictResponses));
+        print("outbound request", OBJECT_MAPPER.writeValueAsString(
+            OutboundRequestCompositionExample.buildInventoryLookupRequest()
+        ));
+        print("outbound notification", OBJECT_MAPPER.writeValueAsString(
+            OutboundRequestCompositionExample.buildAuditNotification()
+        ));
+        print("outbound batch", OBJECT_MAPPER.writeValueAsString(
+            OutboundRequestCompositionExample.buildOutboundBatch()
+        ));
+        print("manual error object", OBJECT_MAPPER.writeValueAsString(
+            OutboundRequestCompositionExample.buildUpstreamFailureError()
+        ));
     }
 
     static String handle(JsonRpcDispatcher dispatcher, String rawJson) throws JacksonException {

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
@@ -68,6 +68,15 @@ public final class PureJavaDemoApplication {
         print("outbound request", OBJECT_MAPPER.writeValueAsString(
             OutboundRequestCompositionExample.buildInventoryLookupRequest()
         ));
+        print("outbound request from record", OBJECT_MAPPER.writeValueAsString(
+            OutboundRequestCompositionExample.buildInventoryLookupRequestFromRecord()
+        ));
+        print("outbound request from class", OBJECT_MAPPER.writeValueAsString(
+            OutboundRequestCompositionExample.buildTagCreateRequestFromClass()
+        ));
+        print("outbound request from collection", OBJECT_MAPPER.writeValueAsString(
+            OutboundRequestCompositionExample.buildBulkLookupRequestFromCollection()
+        ));
         print("outbound notification", OBJECT_MAPPER.writeValueAsString(
             OutboundRequestCompositionExample.buildAuditNotification()
         ));

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
@@ -68,6 +68,9 @@ public final class PureJavaDemoApplication {
         print("outbound request", OBJECT_MAPPER.writeValueAsString(
             OutboundRequestCompositionExample.buildInventoryLookupRequest()
         ));
+        print("outbound request with paramsArray", OBJECT_MAPPER.writeValueAsString(
+            OutboundRequestCompositionExample.buildInventoryReserveRequestWithParamsArray()
+        ));
         print("outbound request from record", OBJECT_MAPPER.writeValueAsString(
             OutboundRequestCompositionExample.buildInventoryLookupRequestFromRecord()
         ));

--- a/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
+++ b/samples/pure-java-demo/src/main/java/com/limehee/jsonrpc/sample/purejava/PureJavaDemoApplication.java
@@ -77,6 +77,9 @@ public final class PureJavaDemoApplication {
         print("outbound request from collection", OBJECT_MAPPER.writeValueAsString(
             OutboundRequestCompositionExample.buildBulkLookupRequestFromCollection()
         ));
+        print("outbound request from map", OBJECT_MAPPER.writeValueAsString(
+            OutboundRequestCompositionExample.buildHealthSnapshotRequestFromMap()
+        ));
         print("outbound notification", OBJECT_MAPPER.writeValueAsString(
             OutboundRequestCompositionExample.buildAuditNotification()
         ));

--- a/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java
+++ b/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java
@@ -23,6 +23,18 @@ class OutboundRequestCompositionExampleTest {
     }
 
     @Test
+    void buildsSingleRequestPayloadWithArrayParams() {
+        ObjectNode request = OutboundRequestCompositionExample.buildInventoryReserveRequestWithParamsArray();
+
+        assertEquals("inventory.reserve", request.get("method").stringValue());
+        assertEquals(10L, request.get("id").longValue());
+        assertTrue(request.get("params").isArray());
+        assertEquals("book-001", request.get("params").get(0).stringValue());
+        assertEquals(2, request.get("params").get(1).intValue());
+        assertTrue(request.get("params").get(2).booleanValue());
+    }
+
+    @Test
     void buildsRequestPayloadFromRecord() {
         ObjectNode request = OutboundRequestCompositionExample.buildInventoryLookupRequestFromRecord();
 

--- a/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java
+++ b/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java
@@ -1,0 +1,56 @@
+package com.limehee.jsonrpc.sample.purejava;
+
+import com.limehee.jsonrpc.core.JsonRpcError;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OutboundRequestCompositionExampleTest {
+
+    @Test
+    void buildsSingleRequestPayloadWithObjectParams() {
+        ObjectNode request = OutboundRequestCompositionExample.buildInventoryLookupRequest();
+
+        assertEquals("2.0", request.get("jsonrpc").stringValue());
+        assertEquals("inventory.lookup", request.get("method").stringValue());
+        assertEquals("req-7", request.get("id").stringValue());
+        assertEquals("book-001", request.get("params").get("sku").stringValue());
+        assertEquals("seoul", request.get("params").get("warehouse").stringValue());
+    }
+
+    @Test
+    void buildsNotificationPayloadWithoutId() {
+        ObjectNode notification = OutboundRequestCompositionExample.buildAuditNotification();
+
+        assertEquals("audit.record", notification.get("method").stringValue());
+        assertFalse(notification.has("id"));
+        assertEquals("inventory.lookup", notification.get("params").get("event").stringValue());
+        assertEquals("gateway", notification.get("params").get("source").stringValue());
+    }
+
+    @Test
+    void buildsBatchPayloadContainingRequestAndNotification() {
+        ArrayNode batch = OutboundRequestCompositionExample.buildOutboundBatch();
+
+        assertEquals(2, batch.size());
+        assertEquals("inventory.lookup", batch.get(0).get("method").stringValue());
+        assertEquals(1L, batch.get(0).get("id").longValue());
+        assertEquals("audit.record", batch.get(1).get("method").stringValue());
+        assertFalse(batch.get(1).has("id"));
+    }
+
+    @Test
+    void createsErrorObjectWithStructuredData() {
+        JsonRpcError error = OutboundRequestCompositionExample.buildUpstreamFailureError();
+
+        assertEquals(-32001, error.code());
+        assertEquals("Inventory upstream failed", error.message());
+        assertTrue(error.data().isObject());
+        assertEquals("trace-123", error.data().get("traceId").stringValue());
+        assertEquals("inventory-gateway", error.data().get("service").stringValue());
+    }
+}

--- a/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java
+++ b/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java
@@ -23,6 +23,38 @@ class OutboundRequestCompositionExampleTest {
     }
 
     @Test
+    void buildsRequestPayloadFromRecord() {
+        ObjectNode request = OutboundRequestCompositionExample.buildInventoryLookupRequestFromRecord();
+
+        assertEquals("inventory.lookup.record", request.get("method").stringValue());
+        assertEquals(11L, request.get("id").longValue());
+        assertEquals("book-002", request.get("params").get("sku").stringValue());
+        assertEquals("busan", request.get("params").get("warehouse").stringValue());
+    }
+
+    @Test
+    void buildsRequestPayloadFromClass() {
+        ObjectNode request = OutboundRequestCompositionExample.buildTagCreateRequestFromClass();
+
+        assertEquals("tag.create", request.get("method").stringValue());
+        assertEquals(12L, request.get("id").longValue());
+        assertEquals("featured", request.get("params").get("name").stringValue());
+        assertEquals("green", request.get("params").get("color").stringValue());
+    }
+
+    @Test
+    void buildsRequestPayloadFromCollection() {
+        ObjectNode request = OutboundRequestCompositionExample.buildBulkLookupRequestFromCollection();
+
+        assertEquals("tags.bulkLookup", request.get("method").stringValue());
+        assertEquals(13L, request.get("id").longValue());
+        assertTrue(request.get("params").isArray());
+        assertEquals("alpha", request.get("params").get(0).stringValue());
+        assertEquals("beta", request.get("params").get(1).stringValue());
+        assertEquals("gamma", request.get("params").get(2).stringValue());
+    }
+
+    @Test
     void buildsNotificationPayloadWithoutId() {
         ObjectNode notification = OutboundRequestCompositionExample.buildAuditNotification();
 

--- a/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java
+++ b/samples/pure-java-demo/src/test/java/com/limehee/jsonrpc/sample/purejava/OutboundRequestCompositionExampleTest.java
@@ -55,6 +55,17 @@ class OutboundRequestCompositionExampleTest {
     }
 
     @Test
+    void buildsRequestPayloadFromMap() {
+        ObjectNode request = OutboundRequestCompositionExample.buildHealthSnapshotRequestFromMap();
+
+        assertEquals("health.snapshot", request.get("method").stringValue());
+        assertEquals(14L, request.get("id").longValue());
+        assertTrue(request.get("params").isObject());
+        assertEquals("ap-northeast-2", request.get("params").get("region").stringValue());
+        assertTrue(request.get("params").get("includeDetails").booleanValue());
+    }
+
+    @Test
     void buildsNotificationPayloadWithoutId() {
         ObjectNode notification = OutboundRequestCompositionExample.buildAuditNotification();
 

--- a/samples/spring-boot-demo/README.md
+++ b/samples/spring-boot-demo/README.md
@@ -219,6 +219,11 @@ jsonrpc:
         policy: STANDARD_ONLY
 ```
 
+The outbound composition example in
+`src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java`
+also shows both direct `paramsObject(...)` and direct `paramsArray(...)` usage, in addition to
+record / POJO / collection / map conversion through `params(JsonNode)`.
+
 Covered by `GreetingRpcServiceValidationProfilesIntegrationTest`:
 
 - request-side validation at the HTTP endpoint (`require-id-member`, fractional ID, polluted request fields, duplicate

--- a/samples/spring-boot-demo/README.md
+++ b/samples/spring-boot-demo/README.md
@@ -236,7 +236,7 @@ application needs to call another JSON-RPC service.
 Covered scenarios:
 
 - single request payload with object params
-- request payloads created from a record, a classic Java class, and a collection
+- request payloads created from a record, a classic Java class, a collection, and a map
 - batch payload containing a request and a notification
 - manual `JsonRpcError.of(code, message, data)` composition for upstream failures
 

--- a/samples/spring-boot-demo/README.md
+++ b/samples/spring-boot-demo/README.md
@@ -225,6 +225,20 @@ Covered by `GreetingRpcServiceValidationProfilesIntegrationTest`:
   members)
 - response-side parser/validator beans (`reject-duplicate-members`, `reject-request-fields`, `error-code.policy`)
 
+## Outbound Request Composition Inside a Spring App
+
+The Spring sample also includes a small core-only example for composing outbound JSON-RPC payloads when the same
+application needs to call another JSON-RPC service.
+
+- `src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java`
+- `src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java`
+
+Covered scenarios:
+
+- single request payload with object params
+- batch payload containing a request and a notification
+- manual `JsonRpcError.of(code, message, data)` composition for upstream failures
+
 ## Test Coverage Entry Points
 
 - `src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceIntegrationTest.java`
@@ -236,3 +250,4 @@ Covered by `GreetingRpcServiceValidationProfilesIntegrationTest`:
 - `src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceErrorDataExposureIntegrationTest.java`
 - `src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceCustomExceptionResolverIntegrationTest.java`
 - `src/test/java/com/limehee/jsonrpc/sample/GreetingRpcServiceValidationProfilesIntegrationTest.java`
+- `src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java`

--- a/samples/spring-boot-demo/README.md
+++ b/samples/spring-boot-demo/README.md
@@ -236,6 +236,7 @@ application needs to call another JSON-RPC service.
 Covered scenarios:
 
 - single request payload with object params
+- request payloads created from a record, a classic Java class, and a collection
 - batch payload containing a request and a notification
 - manual `JsonRpcError.of(code, message, data)` composition for upstream failures
 

--- a/samples/spring-boot-demo/README.md
+++ b/samples/spring-boot-demo/README.md
@@ -48,7 +48,11 @@ curl -s http://localhost:8080/jsonrpc \
 Expected response:
 
 ```json
-{"jsonrpc":"2.0","id":1,"result":"pong"}
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "pong"
+}
 ```
 
 ### 2. Single-parameter DTO binding (`greet`)
@@ -62,7 +66,11 @@ curl -s http://localhost:8080/jsonrpc \
 Expected response:
 
 ```json
-{"jsonrpc":"2.0","id":2,"result":"hello developer"}
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": "hello developer"
+}
 ```
 
 ### 3. Named params with `@JsonRpcParam` (`sum`)
@@ -76,7 +84,11 @@ curl -s http://localhost:8080/jsonrpc \
 Expected response:
 
 ```json
-{"jsonrpc":"2.0","id":3,"result":5}
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": 5
+}
 ```
 
 ### 4. Positional params (`sum`)
@@ -90,7 +102,11 @@ curl -s http://localhost:8080/jsonrpc \
 Expected response:
 
 ```json
-{"jsonrpc":"2.0","id":4,"result":5}
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": 5
+}
 ```
 
 ### 5. Manual registration (`manual.echo`)
@@ -104,7 +120,11 @@ curl -s http://localhost:8080/jsonrpc \
 Expected response:
 
 ```json
-{"jsonrpc":"2.0","id":5,"result":"echo"}
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": "echo"
+}
 ```
 
 ### 6. Typed registration (`typed.upper`, `typed.tags`)
@@ -118,7 +138,13 @@ curl -s http://localhost:8080/jsonrpc \
 Expected response:
 
 ```json
-{"jsonrpc":"2.0","id":6,"result":{"value":"SPRING"}}
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "value": "SPRING"
+  }
+}
 ```
 
 ```bash
@@ -130,7 +156,14 @@ curl -s http://localhost:8080/jsonrpc \
 Expected response:
 
 ```json
-{"jsonrpc":"2.0","id":7,"result":["alpha","beta"]}
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": [
+    "alpha",
+    "beta"
+  ]
+}
 ```
 
 ### 7. Notification (no response body)
@@ -162,8 +195,19 @@ Expected response:
 
 ```json
 [
-  {"jsonrpc":"2.0","id":8,"result":"echo"},
-  {"jsonrpc":"2.0","id":9,"error":{"code":-32601,"message":"Method not found"}}
+  {
+    "jsonrpc": "2.0",
+    "id": 8,
+    "result": "echo"
+  },
+  {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "error": {
+      "code": -32601,
+      "message": "Method not found"
+    }
+  }
 ]
 ```
 
@@ -178,7 +222,14 @@ curl -s http://localhost:8080/jsonrpc \
 Expected response:
 
 ```json
-{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": {
+    "code": -32700,
+    "message": "Parse error"
+  }
+}
 ```
 
 ## Notification Executor Scenarios

--- a/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
+++ b/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
@@ -13,6 +13,12 @@ import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Sample outbound JSON-RPC payload composition for a Spring Boot application that also acts as a client.
+ * <p>
+ * The Spring Boot sample primarily demonstrates server-side request handling through
+ * {@code jsonrpc-spring-boot-starter}, but real applications often need to call another JSON-RPC service as part of
+ * the same request flow. This example exists to show that outbound payload composition stays in
+ * {@code jsonrpc-core} and can be used directly from a Spring application without any transport-specific helper.
+ * </p>
  */
 public final class OutboundRequestCompositionExample {
 

--- a/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
+++ b/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
@@ -1,0 +1,43 @@
+package com.limehee.jsonrpc.sample;
+
+import com.limehee.jsonrpc.core.JsonRpcError;
+import com.limehee.jsonrpc.core.JsonRpcRequestBatchBuilder;
+import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+
+public final class OutboundRequestCompositionExample {
+
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+
+    private OutboundRequestCompositionExample() {
+    }
+
+    public static ObjectNode buildInventoryLookupRequest() {
+        return JsonRpcRequestBuilder.request("inventory.lookup")
+            .id("req-21")
+            .paramsObject(params -> {
+                params.put("sku", "book-001");
+                params.put("warehouse", "spring");
+            })
+            .buildNode();
+    }
+
+    public static ArrayNode buildInventoryAuditBatch() {
+        return new JsonRpcRequestBatchBuilder()
+            .add(JsonRpcRequestBuilder.request("inventory.lookup").id(21L))
+            .addNotification("audit.record", request -> request.paramsObject(params -> {
+                params.put("event", "inventory.lookup");
+                params.put("source", "spring-boot-demo");
+            }))
+            .buildNode();
+    }
+
+    public static JsonRpcError buildUpstreamFailureError() {
+        ObjectNode data = NODE_FACTORY.objectNode();
+        data.put("traceId", "trace-spring-123");
+        data.put("service", "inventory-gateway");
+        return JsonRpcError.of(-32001, "Inventory upstream failed", data);
+    }
+}

--- a/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
+++ b/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
@@ -4,6 +4,7 @@ import com.limehee.jsonrpc.core.JsonRpcError;
 import com.limehee.jsonrpc.core.JsonRpcRequestBatchBuilder;
 import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
 import java.util.List;
+import java.util.Map;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
@@ -114,6 +115,33 @@ public final class OutboundRequestCompositionExample {
         return JsonRpcRequestBuilder.request("tags.bulkLookup")
             .id(24L)
             .params(OBJECT_MAPPER.valueToTree(List.of("alpha", "beta", "gamma")))
+            .buildNode();
+    }
+
+    /**
+     * Builds a request from a map converted through Jackson.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "health.snapshot",
+     *   "id": 25,
+     *   "params": {
+     *     "region": "ap-northeast-2",
+     *     "includeDetails": true
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildHealthSnapshotRequestFromMap() {
+        return JsonRpcRequestBuilder.request("health.snapshot")
+            .id(25L)
+            .params(OBJECT_MAPPER.valueToTree(Map.of(
+                "region", "ap-northeast-2",
+                "includeDetails", true
+            )))
             .buildNode();
     }
 

--- a/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
+++ b/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
@@ -3,17 +3,41 @@ package com.limehee.jsonrpc.sample;
 import com.limehee.jsonrpc.core.JsonRpcError;
 import com.limehee.jsonrpc.core.JsonRpcRequestBatchBuilder;
 import com.limehee.jsonrpc.core.JsonRpcRequestBuilder;
+import java.util.List;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 import tools.jackson.databind.node.ObjectNode;
 
+/**
+ * Sample outbound JSON-RPC payload composition for a Spring Boot application that also acts as a client.
+ */
 public final class OutboundRequestCompositionExample {
 
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
     private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
 
     private OutboundRequestCompositionExample() {
     }
 
+    /**
+     * Builds a request with object-style params using direct node composition.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "inventory.lookup",
+     *   "id": "req-21",
+     *   "params": {
+     *     "sku": "book-001",
+     *     "warehouse": "spring"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
     public static ObjectNode buildInventoryLookupRequest() {
         return JsonRpcRequestBuilder.request("inventory.lookup")
             .id("req-21")
@@ -24,6 +48,98 @@ public final class OutboundRequestCompositionExample {
             .buildNode();
     }
 
+    /**
+     * Builds a request from a record converted through Jackson.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "inventory.lookup.record",
+     *   "id": 22,
+     *   "params": {
+     *     "sku": "book-002",
+     *     "warehouse": "busan"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildInventoryLookupRequestFromRecord() {
+        return JsonRpcRequestBuilder.request("inventory.lookup.record")
+            .id(22L)
+            .params(OBJECT_MAPPER.valueToTree(new InventoryLookupParams("book-002", "busan")))
+            .buildNode();
+    }
+
+    /**
+     * Builds a request from a classic Java class converted through Jackson.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "tag.create",
+     *   "id": 23,
+     *   "params": {
+     *     "name": "featured",
+     *     "color": "green"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildTagCreateRequestFromClass() {
+        return JsonRpcRequestBuilder.request("tag.create")
+            .id(23L)
+            .params(OBJECT_MAPPER.valueToTree(new TagCreateParams("featured", "green")))
+            .buildNode();
+    }
+
+    /**
+     * Builds a request whose params are a JSON array produced from a collection.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "tags.bulkLookup",
+     *   "id": 24,
+     *   "params": ["alpha", "beta", "gamma"]
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildBulkLookupRequestFromCollection() {
+        return JsonRpcRequestBuilder.request("tags.bulkLookup")
+            .id(24L)
+            .params(OBJECT_MAPPER.valueToTree(List.of("alpha", "beta", "gamma")))
+            .buildNode();
+    }
+
+    /**
+     * Builds a mixed batch containing a request and a notification.
+     *
+     * <pre>{@code
+     * [
+     *   {
+     *     "jsonrpc": "2.0",
+     *     "method": "inventory.lookup",
+     *     "id": 21
+     *   },
+     *   {
+     *     "jsonrpc": "2.0",
+     *     "method": "audit.record",
+     *     "params": {
+     *       "event": "inventory.lookup",
+     *       "source": "spring-boot-demo"
+     *     }
+     *   }
+     * ]
+     * }</pre>
+     *
+     * @return outbound batch payload
+     */
     public static ArrayNode buildInventoryAuditBatch() {
         return new JsonRpcRequestBatchBuilder()
             .add(JsonRpcRequestBuilder.request("inventory.lookup").id(21L))
@@ -34,10 +150,48 @@ public final class OutboundRequestCompositionExample {
             .buildNode();
     }
 
+    /**
+     * Builds a structured JSON-RPC error object that can be embedded into a response payload.
+     *
+     * <pre>{@code
+     * {
+     *   "code": -32001,
+     *   "message": "Inventory upstream failed",
+     *   "data": {
+     *     "traceId": "trace-spring-123",
+     *     "service": "inventory-gateway"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @return JSON-RPC error object
+     */
     public static JsonRpcError buildUpstreamFailureError() {
         ObjectNode data = NODE_FACTORY.objectNode();
         data.put("traceId", "trace-spring-123");
         data.put("service", "inventory-gateway");
         return JsonRpcError.of(-32001, "Inventory upstream failed", data);
+    }
+
+    public record InventoryLookupParams(String sku, String warehouse) {
+    }
+
+    public static final class TagCreateParams {
+
+        private final String name;
+        private final String color;
+
+        public TagCreateParams(String name, String color) {
+            this.name = name;
+            this.color = color;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getColor() {
+            return color;
+        }
     }
 }

--- a/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
+++ b/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
@@ -56,6 +56,31 @@ public final class OutboundRequestCompositionExample {
     }
 
     /**
+     * Builds a request with positional params using the dedicated array builder API.
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "method": "inventory.reserve",
+     *   "id": 26,
+     *   "params": ["book-001", 2, true]
+     * }
+     * }</pre>
+     *
+     * @return outbound request payload
+     */
+    public static ObjectNode buildInventoryReserveRequestWithParamsArray() {
+        return JsonRpcRequestBuilder.request("inventory.reserve")
+            .id(26L)
+            .paramsArray(
+                NODE_FACTORY.stringNode("book-001"),
+                NODE_FACTORY.numberNode(2),
+                NODE_FACTORY.booleanNode(true)
+            )
+            .buildNode();
+    }
+
+    /**
      * Builds a request from a record converted through Jackson.
      *
      * <pre>{@code

--- a/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
+++ b/samples/spring-boot-demo/src/main/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExample.java
@@ -15,9 +15,9 @@ import tools.jackson.databind.node.ObjectNode;
  * Sample outbound JSON-RPC payload composition for a Spring Boot application that also acts as a client.
  * <p>
  * The Spring Boot sample primarily demonstrates server-side request handling through
- * {@code jsonrpc-spring-boot-starter}, but real applications often need to call another JSON-RPC service as part of
- * the same request flow. This example exists to show that outbound payload composition stays in
- * {@code jsonrpc-core} and can be used directly from a Spring application without any transport-specific helper.
+ * {@code jsonrpc-spring-boot-starter}, but real applications often need to call another JSON-RPC service as part of the
+ * same request flow. This example exists to show that outbound payload composition stays in {@code jsonrpc-core} and
+ * can be used directly from a Spring application without any transport-specific helper.
  * </p>
  */
 public final class OutboundRequestCompositionExample {
@@ -233,6 +233,7 @@ public final class OutboundRequestCompositionExample {
     }
 
     public record InventoryLookupParams(String sku, String warehouse) {
+
     }
 
     public static final class TagCreateParams {

--- a/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java
+++ b/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java
@@ -1,0 +1,47 @@
+package com.limehee.jsonrpc.sample;
+
+import com.limehee.jsonrpc.core.JsonRpcError;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OutboundRequestCompositionExampleTest {
+
+    @Test
+    void buildsSingleRequestPayloadForUpstreamCall() {
+        ObjectNode request = OutboundRequestCompositionExample.buildInventoryLookupRequest();
+
+        assertEquals("2.0", request.get("jsonrpc").stringValue());
+        assertEquals("inventory.lookup", request.get("method").stringValue());
+        assertEquals("req-21", request.get("id").stringValue());
+        assertEquals("book-001", request.get("params").get("sku").stringValue());
+        assertEquals("spring", request.get("params").get("warehouse").stringValue());
+    }
+
+    @Test
+    void buildsBatchPayloadContainingRequestAndNotification() {
+        ArrayNode batch = OutboundRequestCompositionExample.buildInventoryAuditBatch();
+
+        assertEquals(2, batch.size());
+        assertEquals("inventory.lookup", batch.get(0).get("method").stringValue());
+        assertEquals(21L, batch.get(0).get("id").longValue());
+        assertEquals("audit.record", batch.get(1).get("method").stringValue());
+        assertFalse(batch.get(1).has("id"));
+        assertEquals("spring-boot-demo", batch.get(1).get("params").get("source").stringValue());
+    }
+
+    @Test
+    void createsStructuredErrorObjectForUpstreamFailure() {
+        JsonRpcError error = OutboundRequestCompositionExample.buildUpstreamFailureError();
+
+        assertEquals(-32001, error.code());
+        assertEquals("Inventory upstream failed", error.message());
+        assertTrue(error.data().isObject());
+        assertEquals("trace-spring-123", error.data().get("traceId").stringValue());
+        assertEquals("inventory-gateway", error.data().get("service").stringValue());
+    }
+}

--- a/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java
+++ b/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java
@@ -23,6 +23,18 @@ class OutboundRequestCompositionExampleTest {
     }
 
     @Test
+    void buildsSingleRequestPayloadWithArrayParams() {
+        ObjectNode request = OutboundRequestCompositionExample.buildInventoryReserveRequestWithParamsArray();
+
+        assertEquals("inventory.reserve", request.get("method").stringValue());
+        assertEquals(26L, request.get("id").longValue());
+        assertTrue(request.get("params").isArray());
+        assertEquals("book-001", request.get("params").get(0).stringValue());
+        assertEquals(2, request.get("params").get(1).intValue());
+        assertTrue(request.get("params").get(2).booleanValue());
+    }
+
+    @Test
     void buildsRequestPayloadFromRecord() {
         ObjectNode request = OutboundRequestCompositionExample.buildInventoryLookupRequestFromRecord();
 

--- a/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java
+++ b/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java
@@ -55,6 +55,17 @@ class OutboundRequestCompositionExampleTest {
     }
 
     @Test
+    void buildsRequestPayloadFromMap() {
+        ObjectNode request = OutboundRequestCompositionExample.buildHealthSnapshotRequestFromMap();
+
+        assertEquals("health.snapshot", request.get("method").stringValue());
+        assertEquals(25L, request.get("id").longValue());
+        assertTrue(request.get("params").isObject());
+        assertEquals("ap-northeast-2", request.get("params").get("region").stringValue());
+        assertTrue(request.get("params").get("includeDetails").booleanValue());
+    }
+
+    @Test
     void buildsBatchPayloadContainingRequestAndNotification() {
         ArrayNode batch = OutboundRequestCompositionExample.buildInventoryAuditBatch();
 

--- a/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java
+++ b/samples/spring-boot-demo/src/test/java/com/limehee/jsonrpc/sample/OutboundRequestCompositionExampleTest.java
@@ -23,6 +23,38 @@ class OutboundRequestCompositionExampleTest {
     }
 
     @Test
+    void buildsRequestPayloadFromRecord() {
+        ObjectNode request = OutboundRequestCompositionExample.buildInventoryLookupRequestFromRecord();
+
+        assertEquals("inventory.lookup.record", request.get("method").stringValue());
+        assertEquals(22L, request.get("id").longValue());
+        assertEquals("book-002", request.get("params").get("sku").stringValue());
+        assertEquals("busan", request.get("params").get("warehouse").stringValue());
+    }
+
+    @Test
+    void buildsRequestPayloadFromClass() {
+        ObjectNode request = OutboundRequestCompositionExample.buildTagCreateRequestFromClass();
+
+        assertEquals("tag.create", request.get("method").stringValue());
+        assertEquals(23L, request.get("id").longValue());
+        assertEquals("featured", request.get("params").get("name").stringValue());
+        assertEquals("green", request.get("params").get("color").stringValue());
+    }
+
+    @Test
+    void buildsRequestPayloadFromCollection() {
+        ObjectNode request = OutboundRequestCompositionExample.buildBulkLookupRequestFromCollection();
+
+        assertEquals("tags.bulkLookup", request.get("method").stringValue());
+        assertEquals(24L, request.get("id").longValue());
+        assertTrue(request.get("params").isArray());
+        assertEquals("alpha", request.get("params").get(0).stringValue());
+        assertEquals("beta", request.get("params").get(1).stringValue());
+        assertEquals("gamma", request.get("params").get(2).stringValue());
+    }
+
+    @Test
     void buildsBatchPayloadContainingRequestAndNotification() {
         ArrayNode batch = OutboundRequestCompositionExample.buildInventoryAuditBatch();
 


### PR DESCRIPTION
## Summary

This PR adds outbound JSON-RPC request composition support to `jsonrpc-core` and rounds it out with runnable samples, tests, and documentation.

Main changes:
- Added `JsonRpcRequestBuilder` for single request / notification payload composition
- Added `JsonRpcRequestBatchBuilder` for batch payload composition
- Added `JsonRpcError.of(code, message, data)` overload for structured error object creation
- Clarified that `JsonRpcRequest` is a parser output / dispatcher model, not the primary outbound composition API
- Added fail-fast validation and edge-case coverage for builder APIs
- Added runnable outbound composition examples to both pure Java and Spring sample modules
- Expanded sample scenarios to cover direct object params, record params, classic Java class params, collection params, and map params
- Added Javadoc examples that show the exact JSON produced by sample composition methods
- Linked root docs directly to runnable sample classes

## Related Issues

- Closes #22
- Related #

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Test
- [ ] Build/CI

## JSON-RPC Impact

Describe protocol-level impact, if any:

- [x] No protocol behavior change
- [ ] Request validation behavior changed
- [ ] Error mapping behavior changed
- [ ] Method registration/dispatch behavior changed

Details:
- This change adds outbound payload composition utilities on top of the existing protocol model.
- Server-side dispatch behavior remains unchanged.
- `JsonRpcError` now has a convenience factory for structured `data` payloads.
- Builder contracts are fail-fast and RFC-oriented:
  - requests require `id`
  - notifications reject `id`
  - `params(...)`, `paramsArray(...)`, and `paramsObject(...)` are mutually exclusive
  - empty batch payloads are rejected

## Validation

- [x] `./gradlew test`
- [x] `./gradlew check`
- [x] Added/updated tests for new behavior

Additional verification performed:
- [x] `./gradlew :jsonrpc-core:test --no-daemon`
- [x] `./gradlew -p samples/pure-java-demo test --no-daemon`
- [x] `./gradlew -p samples/spring-boot-demo test --no-daemon`

## Documentation

- [x] Updated README (if needed)
- [x] Added migration notes for breaking changes (if any)

Notes:
- No breaking migration is required.
- Root guides now link directly to runnable sample code.
- Sample modules now include outbound composition examples for:
  - single request
  - notification
  - batch request
  - structured error objects
  - record / POJO / collection / map based params